### PR TITLE
Remove CreateValidator and minimize functions, splitted contracts and…

### DIFF
--- a/contracts/sfc/NodeInterface.sol
+++ b/contracts/sfc/NodeInterface.sol
@@ -11,10 +11,8 @@ interface NodeInterface {
 
     event UpdatedValidatorWeight(uint256 indexed validatorID, uint256 weight);
 
-    event UpdatedGasPowerAllocationRate(uint256 short, uint256 long);
-    event UpdatedMinGasPrice(uint256 minGasPrice);
 
     function _deactivateValidator(uint256 validatorID, uint256 status) external;
-    function _sealEpochValidators(uint256[] calldata nextValidatorIDs) external;
-    function _sealEpoch(uint256[] calldata offlineTimes, uint256[] calldata offlineBlocks, uint256[] calldata uptimes, uint256[] calldata originatedTxsFee) external;
+    function sealEpochValidators(uint256[] calldata nextValidatorIDs) external;
+    function sealEpoch(uint256[] calldata offlineTimes, uint256[] calldata offlineBlocks, uint256[] calldata uptimes, uint256[] calldata originatedTxsFee) external;
 }

--- a/contracts/sfc/SFCInterface.sol
+++ b/contracts/sfc/SFCInterface.sol
@@ -1,0 +1,51 @@
+pragma solidity ^0.5.0;
+
+contract SFCInterface {
+    /**
+ * @dev The staking for validation
+ */
+    struct Validator {
+        uint256 status;
+        uint256 deactivatedTime;
+        uint256 deactivatedEpoch;
+        uint256 receivedStake;
+        uint256 createdEpoch;
+        uint256 createdTime;
+        address auth;
+        bytes pubkey;
+    }
+
+    struct UnstakingRequest {
+        uint256 epoch;
+        uint256 time;
+        uint256 amount;
+    }
+
+    struct EpochSnapshot {
+        mapping(uint256 => uint256) receivedStakes;
+        mapping(uint256 => uint256) accumulatedRewardPerToken;
+        mapping(uint256 => uint256) accumulatedUptimes;
+        mapping(uint256 => uint256) accumulatedOriginatedTxsFee;
+        mapping(uint256 => uint256) offlineTimes;
+        mapping(uint256 => uint256) offlineBlocks;
+
+        uint256[] validatorIDs;
+
+        uint256 endTime;
+        uint256 epochFee;
+        uint256 totalBaseRewardWeight;
+        uint256 totalTxRewardWeight;
+        uint256 baseRewardPerSecond;
+        uint256 totalStake;
+        uint256 totalSupply;
+    }
+
+    struct _SealEpochRewardsCtx {
+        uint256[] baseRewardWeights;
+        uint256 totalBaseRewardWeight;
+        uint256[] txRewardWeights;
+        uint256 totalTxRewardWeight;
+        uint256 epochDuration;
+        uint256 epochFee;
+    }
+}

--- a/contracts/sfc/SFCInterface.sol
+++ b/contracts/sfc/SFCInterface.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-contract SFCInterface {
+interface SFCInterface {
     /**
  * @dev The staking for validation
  */

--- a/contracts/sfc/Storage.sol
+++ b/contracts/sfc/Storage.sol
@@ -1,0 +1,32 @@
+pragma solidity ^0.5.0;
+
+import "./SFCInterface.sol";
+
+contract Storage is SFCInterface {
+
+
+    // Validator
+    mapping(uint256 => Validator) public getValidator;
+    mapping(address => uint256) public getValidatorID;
+    mapping(uint256 => bytes) public validatorMetadata;
+
+
+    mapping(address => mapping(uint256 => mapping(uint256 => UnstakingRequest))) public getUnstakingRequest;
+    mapping(address => mapping(uint256 => uint256)) public rewardsStash; // addr, validatorID -> StashedRewards
+    mapping(address => mapping(uint256 => uint256)) public getDelegation;
+    mapping(uint256 => EpochSnapshot) public getEpochSnapshot;
+    mapping(address => mapping(uint256 => uint256)) public claimedRewardUntilEpoch;
+
+    uint256 public currentSealedEpoch;
+    uint256 public lastValidatorID;
+    uint256 public totalStake;
+    uint256 public totalSlashedStake;
+    uint256 offlinePenaltyThresholdBlocksNum;
+    uint256 offlinePenaltyThresholdTime;
+    uint256 public baseRewardPerSecond;
+    uint256 public totalSupply;
+
+    event UpdatedBaseRewardPerSec(uint256 value);
+    event UpdatedOfflinePenaltyThreshold(uint256 blocksNum, uint256 period);
+
+}

--- a/contracts/sfc/delegator/DelegationRegistry.sol
+++ b/contracts/sfc/delegator/DelegationRegistry.sol
@@ -1,0 +1,44 @@
+pragma solidity ^0.5.0;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "../interface/IDelegationRegistry.sol";
+
+/**
+ * @dev A registry for all delegations
+ */
+contract DelegationRegistry is IDelegationRegistry {
+    using SafeMath for uint256;
+
+    constructor() public {
+
+    }
+
+    mapping(address => mapping(uint256 => uint256)) public delegations;
+
+    function createDelegation(uint256 toValidatorID, uint256 urID, uint256 amount) external payable {
+
+    }
+
+    function startUndelegate(uint256 toValidatorID, uint256 urID, uint256 amount) external {
+
+    }
+
+    function finishUndelegate(uint256 toValidatorID, uint256 urID) external {
+
+    }
+
+    function delegationAmount(address addr, uint256 urID) public view returns (uint256)  {
+        return delegations[addr][urID];
+    }
+
+    function increase(address addr, uint256 urID, uint256 amount) external {
+        delegations[addr][urID] = delegations[addr][urID].add(amount);
+    }
+
+    function decrease(address addr, uint256 urID, uint256 amount) external {
+        delegations[addr][urID] -= amount;
+    }
+
+
+    //    function _delegationExists(uint256 validatorID, uint256 urID) view internal returns (bool);
+}

--- a/contracts/sfc/interface/IDelegation.sol
+++ b/contracts/sfc/interface/IDelegation.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.5.0;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+/**
+ * @dev Delegation
+ */
+interface IDelegation {
+
+    struct Delegation {
+        uint256 startedEpoch;
+        uint256 duration;
+        uint256 amount;
+    }
+
+//    struct DelegationStorage {
+//
+//    }
+}

--- a/contracts/sfc/interface/IDelegationRegistry.sol
+++ b/contracts/sfc/interface/IDelegationRegistry.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.5.0;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+/**
+ * @dev A registry for all delegations
+ */
+interface IDelegationRegistry {
+    using SafeMath for uint256;
+
+    function createDelegation(uint256 toValidatorID, uint256 urID, uint256 amount) external payable;
+
+    function startUndelegate(uint256 toValidatorID, uint256 urID, uint256 amount) external;
+
+    function finishUndelegate(uint256 toValidatorID, uint256 urID) external;
+
+    //    function _delegationExists(uint256 validatorID, uint256 urID) view internal returns (bool);
+}

--- a/contracts/sfc/interface/ILockable.sol
+++ b/contracts/sfc/interface/ILockable.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.5.0;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+interface ILockable {
+    using SafeMath for uint256;
+
+    function lock(uint256 duration) external payable;
+
+    function unlock() external payable;
+
+}

--- a/contracts/sfc/interface/INode.sol
+++ b/contracts/sfc/interface/INode.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.5.0;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+/**
+ * @dev INode
+ */
+interface INode {
+    /**
+     * @dev List of events
+     */
+
+    event IncBalance(address indexed acc, uint256 value);
+    //    event SetBalance(address indexed acc, uint256 value);
+    //    event SubBalance(address indexed acc, uint256 value);
+    //    event SetCode(address indexed acc, address indexed from);
+    //    event SwapCode(address indexed acc, address indexed with);
+    //    event SetStorage(address indexed acc, uint256 key, uint256 value);
+
+    event UpdatedValidatorWeight(uint256 indexed validatorID, uint256 weight);
+
+
+    //
+    function _deactivateValidator(int256 validatorID, uint256 status) external;
+
+    //
+    function sealEpochValidators(uint256[] calldata nextValidatorIDs) external;
+
+    //
+    function sealEpoch(
+        uint256[] calldata offlineTimes,
+        uint256[] calldata offlineBlocks,
+        uint256[] calldata uptimes,
+        uint256[] calldata originatedTxsFee)  external;
+
+    // other functions
+    // offline validator
+    //
+}

--- a/contracts/sfc/interface/IReward.sol
+++ b/contracts/sfc/interface/IReward.sol
@@ -1,0 +1,29 @@
+pragma solidity ^0.5.0;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+/**
+ * @dev IReward
+ */
+interface IReward {
+
+    function pendingRewards(address delegator, uint256 toValidatorID) external view returns (uint256);
+
+    function stashRewards(address delegator, uint256 toValidatorID) external;
+
+    function claimRewards(uint256 toValidatorID) external;
+
+    function offlinePenaltyThreshold() external view returns (uint256 blocksNum, uint256 time);
+
+    function updateBaseRewardPerSecond(uint256 value) external;
+
+    function updateOfflinePenaltyThreshold(uint256 blocksNum, uint256 time) external;
+
+//    function _calcRawValidatorEpochBaseReward(uint256 epochDuration, uint256 baseRewardPerSecond, uint256 baseRewardWeight, uint256 totalBaseRewardWeight) internal pure returns (uint256);
+//
+//    function _calcRawValidatorEpochTxReward(uint256 epochFee, uint256 txRewardWeight, uint256 totalTxRewardWeight) internal pure returns (uint256);
+//
+//    function _calcValidatorCommission(uint256 rawReward, uint256 commission) internal pure returns (uint256);
+//
+//    function _highestPayableEpoch(uint256 validatorID) internal view returns (uint256);
+}

--- a/contracts/sfc/interface/IValidatorRegistry.sol
+++ b/contracts/sfc/interface/IValidatorRegistry.sol
@@ -1,0 +1,35 @@
+pragma solidity ^0.5.0;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+/**
+ * @dev A registry for all validators
+ */
+interface IValidatorRegistry {
+    using SafeMath for uint256;
+
+    function setGenesisDelegation(address delegator, uint256 toValidatorID, uint256 amount, uint256 rewards) external;
+
+    function createValidator(bytes calldata pubkey) external payable;
+
+    function stake(uint256 toValidatorID) external payable;
+
+    function startUnstake(uint256 toValidatorID, uint256 urID, uint256 amount) external;
+
+    function finishUnstake(uint256 toValidatorID, uint256 urID) external;
+
+    function deactivateValidator(uint256 validatorID, uint256 status) external;
+
+//    function _isSelfStake(address delegator, uint256 toValidatorID) internal view returns (bool);
+
+//    function _getSelfStake(uint256 validatorID) internal view returns (uint256);
+
+//    function _checkDelegatedStakeLimit(uint256 validatorID) internal view returns (bool);
+
+//    function _setValidatorDeactivated(uint256 validatorID, uint256 status) internal;
+
+    // _syncValidator updates the validator data on node
+//    function _syncValidator(uint256 validatorID) public;
+
+//    function _validatorExists(uint256 validatorID) view internal returns (bool);
+}

--- a/contracts/sfc/node/Node.sol
+++ b/contracts/sfc/node/Node.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.5.0;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "../interface/INode.sol";
+
+/**
+ * @dev Node
+ */
+contract Node is INode {
+    //
+    function _deactivateValidator(int256 validatorID, uint256 status) external {}
+
+    //
+    function sealEpochValidators(uint256[] calldata nextValidatorIDs) external {}
+
+    //
+    function sealEpoch(
+        uint256[] calldata offlineTimes,
+        uint256[] calldata offlineBlocks,
+        uint256[] calldata uptimes,
+        uint256[] calldata originatedTxsFee)  external {}
+
+    // other functions
+    // offline validator
+    //
+}

--- a/contracts/sfc/validator/Reward.sol
+++ b/contracts/sfc/validator/Reward.sol
@@ -1,0 +1,104 @@
+pragma solidity ^0.5.0;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "../interface/IReward.sol";
+import "../interface/INode.sol";
+import "../../common/Decimal.sol";
+import "../../ownership/Ownable.sol";
+import "./Storage.sol";
+import "./ValidatorRegistry.sol";
+
+/**
+ * @dev Reward
+ */
+contract Reward is Ownable, IReward, INode, Storage {
+    using SafeMath for uint256;
+
+//    struct EpochSnapshot {
+//        mapping(uint256 => uint256) receivedStakes;
+//        mapping(uint256 => uint256) accumulatedRewardPerToken;
+//        mapping(uint256 => uint256) accumulatedUptimes;
+//        mapping(uint256 => uint256) accumulatedOriginatedTxsFee;
+//        mapping(uint256 => uint256) offlineTimes;
+//        mapping(uint256 => uint256) offlineBlocks;
+//
+//        uint256[] validatorIDs;
+//
+//        uint256 endTime;
+//        uint256 epochFee;
+//        uint256 totalBaseRewardWeight;
+//        uint256 totalTxRewardWeight;
+//        uint256 baseRewardPerSecond;
+//        uint256 totalStake;
+//        uint256 totalSupply;
+//    }
+//
+//    mapping(address => mapping(uint256 => uint256)) public rewardsStash; // addr, validatorID -> StashedRewards
+//    mapping(address => mapping(uint256 => uint256)) public delegations;
+//    mapping(uint256 => EpochSnapshot) public getEpochSnapshot;
+//    mapping(address => mapping(uint256 => uint256)) public claimedRewardUntilEpoch;
+
+    constructor(Storage store) public {
+
+    }
+
+    Storage store;
+
+    function pendingRewards(address delegator, uint256 toValidatorID) public view returns (uint256) {
+        uint256 claimedUntil = claimedRewardUntilEpoch[delegator][toValidatorID];
+        uint256 claimedRate = getEpochSnapshot[claimedUntil].accumulatedRewardPerToken[toValidatorID];
+        uint256 currentRate = getEpochSnapshot[_highestPayableEpoch(toValidatorID)].accumulatedRewardPerToken[toValidatorID];
+        uint256 pending = currentRate.sub(claimedRate).mul(delegations[delegator][toValidatorID]).div(Decimal.unit());
+        return rewardsStash[delegator][toValidatorID].add(pending);
+    }
+
+    function _highestPayableEpoch(uint256 validatorID) internal view returns (uint256) {
+        if (validators[validatorID].deactivatedEpoch != 0) {
+            if (currentSealedEpoch < validators[validatorID].deactivatedEpoch) {
+                return currentSealedEpoch;
+            }
+            return validators[validatorID].deactivatedEpoch;
+        }
+        return currentSealedEpoch;
+    }
+
+    function stashRewards(address delegator, uint256 toValidatorID) external {
+        require(_stashRewards(delegator, toValidatorID), "nothing to stash");
+    }
+
+    function _stashRewards(address delegator, uint256 toValidatorID) public returns (bool updated) {
+        uint256 pending = pendingRewards(delegator, toValidatorID);
+        claimedRewardUntilEpoch[delegator][toValidatorID] = _highestPayableEpoch(toValidatorID);
+        if (rewardsStash[delegator][toValidatorID] == pending) {
+            return false;
+        }
+        rewardsStash[delegator][toValidatorID] = pending;
+        return true;
+    }
+
+    function claimRewards(uint256 toValidatorID) external {
+        address payable delegator = msg.sender;
+        uint256 pending = pendingRewards(delegator, toValidatorID);
+        require(pending != 0, "zero rewards");
+        delete rewardsStash[delegator][toValidatorID];
+        claimedRewardUntilEpoch[delegator][toValidatorID] = _highestPayableEpoch(toValidatorID);
+        // It's important that we transfer after erasing (protection against Re-Entrancy)
+        delegator.transfer(pending);
+        emit IncBalance(address(this), pending);
+    }
+
+    function offlinePenaltyThreshold() public view returns (uint256 blocksNum, uint256 time) {
+        return (offlinePenaltyThresholdBlocksNum, offlinePenaltyThresholdTime);
+    }
+
+    function updateBaseRewardPerSecond(uint256 value) onlyOwner external {
+        baseRewardPerSecond = value;
+        emit UpdatedBaseRewardPerSec(value);
+    }
+
+    function updateOfflinePenaltyThreshold(uint256 blocksNum, uint256 time) onlyOwner external {
+        offlinePenaltyThresholdTime = time;
+        offlinePenaltyThresholdBlocksNum = blocksNum;
+        emit UpdatedOfflinePenaltyThreshold(blocksNum, time);
+    }
+}

--- a/contracts/sfc/validator/SFCInterface.sol
+++ b/contracts/sfc/validator/SFCInterface.sol
@@ -1,0 +1,52 @@
+pragma solidity ^0.5.0;
+
+interface SFCInterface {
+
+    /**
+     * @dev The staking for validation
+     */
+    struct Validator {
+        uint256 status;
+        uint256 deactivatedTime;
+        uint256 deactivatedEpoch;
+        uint256 receivedStake;
+        uint256 createdEpoch;
+        uint256 createdTime;
+        address auth;
+        bytes pubkey;
+    }
+
+    struct UnstakingRequest {
+        uint256 epoch;
+        uint256 time;
+        uint256 amount;
+    }
+
+    struct EpochSnapshot {
+        mapping(uint256 => uint256) receivedStakes;
+        mapping(uint256 => uint256) accumulatedRewardPerToken;
+        mapping(uint256 => uint256) accumulatedUptimes;
+        mapping(uint256 => uint256) accumulatedOriginatedTxsFee;
+        mapping(uint256 => uint256) offlineTimes;
+        mapping(uint256 => uint256) offlineBlocks;
+
+        uint256[] validatorIDs;
+
+        uint256 endTime;
+        uint256 epochFee;
+        uint256 totalBaseRewardWeight;
+        uint256 totalTxRewardWeight;
+        uint256 baseRewardPerSecond;
+        uint256 totalStake;
+        uint256 totalSupply;
+    }
+
+    struct _SealEpochRewardsCtx {
+        uint256[] baseRewardWeights;
+        uint256 totalBaseRewardWeight;
+        uint256[] txRewardWeights;
+        uint256 totalTxRewardWeight;
+        uint256 epochDuration;
+        uint256 epochFee;
+    }
+}

--- a/contracts/sfc/validator/Storage.sol
+++ b/contracts/sfc/validator/Storage.sol
@@ -1,0 +1,32 @@
+pragma solidity ^0.5.0;
+
+import "./SFCInterface.sol";
+
+contract Storage is SFCInterface {
+
+    constructor() public {}
+
+    // Validator
+    mapping(uint256 => Validator) public validators;
+    mapping(address => uint256) public validatorIDs;
+    // mapping(uint256 => bytes) public validatorMetadata;
+
+    mapping(address => mapping(uint256 => mapping(uint256 => UnstakingRequest))) public getUnstakingRequest;
+    mapping(address => mapping(uint256 => uint256)) public rewardsStash; // addr, validatorID -> StashedRewards
+    mapping(address => mapping(uint256 => uint256)) public delegations;
+    mapping(uint256 => EpochSnapshot) public getEpochSnapshot;
+    mapping(address => mapping(uint256 => uint256)) public claimedRewardUntilEpoch;
+
+    uint256 public currentSealedEpoch;
+    uint256 public lastValidatorID;
+    uint256 public totalStake;
+    uint256 public totalSlashedStake;
+    uint256 offlinePenaltyThresholdBlocksNum;
+    uint256 offlinePenaltyThresholdTime;
+    uint256 public baseRewardPerSecond;
+    uint256 public totalSupply;
+
+    event UpdatedBaseRewardPerSec(uint256 value);
+    event UpdatedOfflinePenaltyThreshold(uint256 blocksNum, uint256 period);
+
+}

--- a/contracts/sfc/validator/ValidatorRegistry.sol
+++ b/contracts/sfc/validator/ValidatorRegistry.sol
@@ -1,0 +1,300 @@
+pragma solidity ^0.5.0;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "../interface/IValidatorRegistry.sol";
+import "../../common/Initializable.sol";
+import "../../common/Decimal.sol";
+import "../node/Node.sol";
+import "../StakerConstants.sol";
+import "../interface/INode.sol";
+import "../delegator/DelegationRegistry.sol";
+import "./Reward.sol";
+import "../../ownership/Ownable.sol";
+
+/**
+ * @dev A registry for all validators
+ */
+contract ValidatorRegistry is IValidatorRegistry, Initializable, StakersConstants, Ownable, INode {
+    using SafeMath for uint256;
+
+    /**
+     * @dev The staking for validation
+     */
+    struct Validator {
+        uint256 status;
+        uint256 deactivatedTime;
+        uint256 deactivatedEpoch;
+        uint256 receivedStake;
+        uint256 createdEpoch;
+        uint256 createdTime;
+        address auth;
+        bytes pubkey;
+    }
+
+    struct UnstakingRequest {
+        uint256 epoch;
+        uint256 time;
+        uint256 amount;
+    }
+
+    // Validator
+    mapping(uint256 => Validator) public validators;
+    mapping(address => uint256) public validatorIDs;
+    mapping(uint256 => bytes) public validatorMetadata;
+
+    mapping(address => mapping(uint256 => mapping(uint256 => UnstakingRequest))) public getUnstakingRequest;
+
+    uint256 public currentSealedEpoch;
+    uint256 public lastValidatorID;
+    uint256 public totalStake;
+    uint256 public totalSlashedStake;
+
+    DelegationRegistry delegationReg;
+
+
+    struct EpochSnapshot {
+        mapping(uint256 => uint256) receivedStakes;
+        mapping(uint256 => uint256) accumulatedRewardPerToken;
+        mapping(uint256 => uint256) accumulatedUptimes;
+        mapping(uint256 => uint256) accumulatedOriginatedTxsFee;
+        mapping(uint256 => uint256) offlineTimes;
+        mapping(uint256 => uint256) offlineBlocks;
+
+        uint256[] validatorIDs;
+
+        uint256 endTime;
+        uint256 epochFee;
+        uint256 totalBaseRewardWeight;
+        uint256 totalTxRewardWeight;
+        uint256 baseRewardPerSecond;
+        uint256 totalStake;
+        uint256 totalSupply;
+    }
+
+    mapping(uint256 => EpochSnapshot) public getEpochSnapshot;
+
+
+
+//    Reward
+    mapping(address => mapping(uint256 => uint256)) public rewardsStash; // addr, validatorID -> StashedRewards
+
+    mapping(address => mapping(uint256 => uint256)) public claimedRewardUntilEpoch;
+
+    uint256 offlinePenaltyThresholdBlocksNum;
+    uint256 offlinePenaltyThresholdTime;
+    uint256 public baseRewardPerSecond;
+    uint256 public totalSupply;
+
+    event UpdatedBaseRewardPerSec(uint256 value);
+    event UpdatedOfflinePenaltyThreshold(uint256 blocksNum, uint256 period);
+
+    function currentEpoch() public view returns (uint256) {
+        return currentSealedEpoch + 1;
+    }
+
+    function setGenesisDelegation(address delegator, uint256 toValidatorID, uint256 amount, uint256 rewards) external notInitialized {
+        _rawStake(delegator, toValidatorID, amount);
+        rewardsStash[delegator][toValidatorID] = rewards;
+    }
+
+    function createValidator(bytes calldata pubkey) external payable {
+        require(msg.value >= minSelfStake(), "insufficient self-stake");
+        _createValidator(msg.sender, pubkey);
+        _stake(msg.sender, lastValidatorID, msg.value);
+    }
+
+    function _createValidator(address auth, bytes memory pubkey) internal {
+        uint256 validatorID = ++lastValidatorID;
+        require(validatorIDs[auth] == 0, "validator already exists");
+        validators[validatorID] = Validator(OK_STATUS, 0, 0, 0, currentEpoch(), now, auth, pubkey);
+    }
+
+    function _isSelfStake(address delegator, uint256 toValidatorID) internal view returns (bool) {
+        return validatorIDs[delegator] == toValidatorID;
+    }
+
+    function _getSelfStake(uint256 validatorID) internal view returns (uint256) {
+//        return delegationReg.delegations[validators[validatorID].auth][validatorID];
+        return delegationReg.delegationAmount(validators[validatorID].auth, validatorID);
+    }
+
+    function _checkDelegatedStakeLimit(uint256 validatorID) internal view returns (bool) {
+        return validators[validatorID].receivedStake <= _getSelfStake(validatorID).mul(maxDelegatedRatio()).div(Decimal.unit());
+    }
+
+    function stake(uint256 toValidatorID) external payable {
+        _stake(msg.sender, toValidatorID, msg.value);
+    }
+
+    function _stake(address delegator, uint256 toValidatorID, uint256 amount) internal {
+        require(validators[toValidatorID].status == OK_STATUS, "validator isn't active");
+        _rawStake(delegator, toValidatorID, amount);
+    }
+
+    function _rawStake(address delegator, uint256 toValidatorID, uint256 amount) internal {
+        require(amount > 0, "zero amount");
+        require(_validatorExists(toValidatorID), "validator doesn't exist");
+
+        _stashRewards(delegator, toValidatorID);
+
+        // delegationReg.delegations[delegator][toValidatorID] = delegationReg.delegations[delegator][toValidatorID].add(amount);
+        delegationReg.increase(delegator, toValidatorID, amount);
+
+        validators[toValidatorID].receivedStake = validators[toValidatorID].receivedStake.add(amount);
+        totalStake = totalStake.add(amount);
+
+        require(_checkDelegatedStakeLimit(toValidatorID), "validator's delegations limit is exceeded");
+        _syncValidator(toValidatorID);
+    }
+
+    function _validatorExists(uint256 validatorID) view internal returns (bool) {
+        return validators[validatorID].createdTime != 0;
+    }
+
+    function startUnstake(uint256 toValidatorID, uint256 urID, uint256 amount) external {
+        address delegator = msg.sender;
+
+        _stashRewards(delegator, toValidatorID);
+
+        require(amount > 0, "zero amount");
+//        require(amount <= delegationReg.delegations[delegator][toValidatorID], "not enough stake");
+        require(amount <= delegationReg.delegationAmount(delegator, toValidatorID), "not enough stake");
+
+        require(getUnstakingRequest[delegator][toValidatorID][urID].amount == 0, "urID already exists");
+
+
+//        delegationReg.delegations[delegator][toValidatorID] -= amount;
+        delegationReg.decrease(delegator, toValidatorID, amount);
+
+        validators[toValidatorID].receivedStake = validators[toValidatorID].receivedStake.sub(amount);
+        totalStake = totalStake.sub(amount);
+
+        require(_checkDelegatedStakeLimit(toValidatorID) || _getSelfStake(toValidatorID) == 0, "validator's delegations limit is exceeded");
+        if (_getSelfStake(toValidatorID) == 0) {
+            _setValidatorDeactivated(toValidatorID, WITHDRAWN_BIT);
+        }
+        getUnstakingRequest[delegator][toValidatorID][urID] = UnstakingRequest(currentEpoch(), now, amount);
+        _syncValidator(toValidatorID);
+    }
+
+    function finishUnstake(uint256 toValidatorID, uint256 urID) external {
+        address payable delegator = msg.sender;
+        UnstakingRequest memory request = getUnstakingRequest[delegator][toValidatorID][urID];
+        require(request.epoch != 0, "request doesn't exist");
+
+        uint256 requestTime = request.time;
+        uint256 requestEpoch = request.epoch;
+        if (validators[toValidatorID].deactivatedTime != 0 && validators[toValidatorID].deactivatedTime < requestTime) {
+            requestTime = validators[toValidatorID].deactivatedTime;
+            requestEpoch = validators[toValidatorID].deactivatedEpoch;
+        }
+
+        require(now >= requestTime + unstakePeriodTime(), "not enough time passed");
+        require(currentEpoch() >= requestEpoch + unstakePeriodEpochs(), "not enough epochs passed");
+
+        uint256 amount = getUnstakingRequest[delegator][toValidatorID][urID].amount;
+        delete getUnstakingRequest[delegator][toValidatorID][urID];
+
+        uint256 slashingPenalty = 0;
+        bool isCheater = validators[toValidatorID].status & CHEATER_MASK != 0;
+
+        // It's important that we transfer after erasing (protection against Re-Entrancy)
+        if (isCheater == false) {
+            delegator.transfer(amount);
+        } else {
+            slashingPenalty = amount;
+        }
+        totalSlashedStake += slashingPenalty;
+    }
+
+    function deactivateValidator(uint256 validatorID, uint256 status) external {
+        require(msg.sender == address(0), "not callable");
+        require(status != OK_STATUS, "wrong status");
+
+        _setValidatorDeactivated(validatorID, status);
+        _syncValidator(validatorID);
+    }
+
+    // _syncValidator updates the validator data on node
+    function _syncValidator(uint256 validatorID) public {
+        require(_validatorExists(validatorID), "validator doesn't exist");
+        // emit special log for node
+        uint256 weight = validators[validatorID].receivedStake;
+        if (validators[validatorID].status != OK_STATUS) {
+            weight = 0;
+        }
+        emit UpdatedValidatorWeight(validatorID, weight);
+    }
+
+    function _setValidatorDeactivated(uint256 validatorID, uint256 status) internal {
+        // status as a number is proportional to severity
+        if (status > validators[validatorID].status) {
+            validators[validatorID].status = status;
+            if (validators[validatorID].deactivatedEpoch == 0) {
+                validators[validatorID].deactivatedTime = now;
+                validators[validatorID].deactivatedEpoch = currentEpoch();
+            }
+        }
+    }
+
+    // Reward functions
+
+
+    function pendingRewards(address delegator, uint256 toValidatorID) public view returns (uint256) {
+        uint256 claimedUntil = claimedRewardUntilEpoch[delegator][toValidatorID];
+        uint256 claimedRate = getEpochSnapshot[claimedUntil].accumulatedRewardPerToken[toValidatorID];
+        uint256 currentRate = getEpochSnapshot[_highestPayableEpoch(toValidatorID)].accumulatedRewardPerToken[toValidatorID];
+        uint256 pending = currentRate.sub(claimedRate).mul(delegationReg.delegationAmount(delegator,toValidatorID)).div(Decimal.unit());
+        return rewardsStash[delegator][toValidatorID].add(pending);
+    }
+
+    function _highestPayableEpoch(uint256 validatorID) internal view returns (uint256) {
+        if (validators[validatorID].deactivatedEpoch != 0) {
+            if (currentSealedEpoch < validators[validatorID].deactivatedEpoch) {
+                return currentSealedEpoch;
+            }
+            return validators[validatorID].deactivatedEpoch;
+        }
+        return currentSealedEpoch;
+    }
+
+    function stashRewards(address delegator, uint256 toValidatorID) external {
+        require(_stashRewards(delegator, toValidatorID), "nothing to stash");
+    }
+
+    function _stashRewards(address delegator, uint256 toValidatorID) public returns (bool updated) {
+        uint256 pending = pendingRewards(delegator, toValidatorID);
+        claimedRewardUntilEpoch[delegator][toValidatorID] = _highestPayableEpoch(toValidatorID);
+        if (rewardsStash[delegator][toValidatorID] == pending) {
+            return false;
+        }
+        rewardsStash[delegator][toValidatorID] = pending;
+        return true;
+    }
+
+    function claimRewards(uint256 toValidatorID) external {
+        address payable delegator = msg.sender;
+        uint256 pending = pendingRewards(delegator, toValidatorID);
+        require(pending != 0, "zero rewards");
+        delete rewardsStash[delegator][toValidatorID];
+        claimedRewardUntilEpoch[delegator][toValidatorID] = _highestPayableEpoch(toValidatorID);
+        // It's important that we transfer after erasing (protection against Re-Entrancy)
+        delegator.transfer(pending);
+        emit IncBalance(address(this), pending);
+    }
+
+    function offlinePenaltyThreshold() public view returns (uint256 blocksNum, uint256 time) {
+        return (offlinePenaltyThresholdBlocksNum, offlinePenaltyThresholdTime);
+    }
+
+    function updateBaseRewardPerSecond(uint256 value) onlyOwner external {
+        baseRewardPerSecond = value;
+        emit UpdatedBaseRewardPerSec(value);
+    }
+
+    function updateOfflinePenaltyThreshold(uint256 blocksNum, uint256 time) onlyOwner external {
+        offlinePenaltyThresholdTime = time;
+        offlinePenaltyThresholdBlocksNum = blocksNum;
+        emit UpdatedOfflinePenaltyThreshold(blocksNum, time);
+    }
+}

--- a/contracts/test/UnitTestSFC.sol
+++ b/contracts/test/UnitTestSFC.sol
@@ -8,12 +8,12 @@ contract UnitTestSFC is SFC {
         return 3.175000 * 1e18;
     }
 
-    function _sealEpoch(uint256[] calldata offlineTimes, uint256[] calldata offlineBlocks, uint256[] calldata uptimes, uint256[] calldata originatedTxsFee) external {
-        __sealEpoch(offlineTimes, offlineBlocks, uptimes, originatedTxsFee);
+    function testSealEpoch(uint256[] calldata offlineTimes, uint256[] calldata offlineBlocks, uint256[] calldata uptimes, uint256[] calldata originatedTxsFee) external {
+        _sealEpoch(offlineTimes, offlineBlocks, uptimes, originatedTxsFee);
     }
 
-    function _sealEpochValidators(uint256[] calldata nextValidatorIDs) external {
-        __sealEpochValidators(nextValidatorIDs);
+    function testSealEpochValidators(uint256[] calldata nextValidatorIDs) external {
+        _sealEpochValidators(nextValidatorIDs);
     }
 
     uint256 public time;


### PR DESCRIPTION
### Refactoring
During the refactoring process, I realized that replacing ValidatorID by Addresses impacted a lot of functions and the entire implementation, so I found it more judicious to clean up the code, simplify it, remove superfluous functions, and calls, before resuming the ValidatorID refactoring process. This will also optimize and simplify future implementations.

**Move**
- Moved all variables and Mapping from `SFC` into a separate contract `Storage` to make it easier to refactor
- Moved all Structs from `SFC` into `SFCInterface`
- Moved `pubkey` into `Validator` Struct

**Remove**
- Removed `_setGenesisValidator` function, as it is exactly the same as `_rawCreateValidator`, unnecessary since the intent of the function is to create the first validator, `_rawCreateValidator`
- Removed `_rawCreateValidator`, `_createValidator` is sufficient,
- Removed Mapping `getValidatorPubkey`, not needed, more optimized to put directly the **pubkey** in the Validator’s struct
- Removed `rawCreateValidator`, `_createValidator`  is sufficient and added a cleaner way to initialize Struct Validator
- Removed `_now` function, as the keyword `now` already exists in Solidity
- Removed `UpdatedMinGasPrice` events, not seeing its utility
- Removed `UpdatedGasPowerAllocationRate` events, not seeing its utility
- Removed `_updateGasPowerAllocationRate` and `_updateMinGasPrice` functions, functions' names are confusing and not used at all, except to emit an event, it is better to emit the event directly rather than declaring functions.
- Removed `MintNativeToken` function, name of the function reflects its utility + no utility except emit an event

**Replace**
- Replaced the call to `MintNativeToken` with event emission directly on the `claimRewards` function

**Rename** to comply with NATSPEC standards, `_` have been removed from public and external functions
- `_setGenesisDelegation` => `setGenesisDelegation`
- `_updateBaseRewardPerSecond` => `updateBaseRewardPerSecond`
- `_updateOfflinePenaltyThreshold` => `updateOfflinePenaltyThreshold`
- `_updateGasPowerAllocationRate` => `updateBaseRewardPerSecond`
- `_updateOfflinePenaltyThreshold` => `updateOfflinePenaltyThreshold`
- `_sealEpochValidators` => `sealEpochValidators` 
- `_deactivateValidator` => `deactivateValidator`
- `_sealEpoch` => `sealEpoch` 