### PR TITLE
Fluid staking economy

### DIFF
--- a/contracts/common/Initializable.sol
+++ b/contracts/common/Initializable.sol
@@ -25,12 +25,6 @@ contract Initializable {
    */
   bool private initializing;
 
-  modifier notInitialized() {
-    require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
-
-    _;
-  }
-
   /**
    * @dev Modifier to use in the initializer function of a contract.
    */

--- a/contracts/sfc/NetworkInitializer.sol
+++ b/contracts/sfc/NetworkInitializer.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.5.0;
+
+import "./SFC.sol";
+import "./NodeDriver.sol";
+
+contract NetworkInitializer {
+    // Initialize NodeDriverAuth, NodeDriver and SFC in one call to allow fewer genesis transactions
+    function initializeAll(uint256 sealedEpoch, uint256 totalSupply, address _sfc, address _auth, address _driver, address _owner) external {
+        NodeDriver(_driver).initialize(_auth, _auth);
+        NodeDriverAuth(_auth).initialize(_sfc, _driver, _owner);
+        SFC(_sfc).initialize(sealedEpoch, totalSupply, _auth, _owner);
+        selfdestruct(address(0));
+    }
+}

--- a/contracts/sfc/NodeDriver.sol
+++ b/contracts/sfc/NodeDriver.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.0;
 
 import "./SFC.sol";
 
-contract NodeInterfaceAuth is Initializable {
+contract NodeDriverAuth is Initializable {
     address public sfc;
     address public owner;
 
@@ -74,14 +74,14 @@ contract NodeInterfaceAuth is Initializable {
     }
 }
 
-contract NodeInterface is Initializable, Ownable {
+contract NodeDriver is Initializable, Ownable {
 
-    NodeInterfaceAuth internal auth;
+    NodeDriverAuth internal auth;
 
     SFC internal sfc;
 
     function setAuth(address _auth) external onlyOwner {
-        auth = NodeInterfaceAuth(_auth);
+        auth = NodeDriverAuth(_auth);
     }
 
     function setSFC(address _sfc) external onlyOwner {
@@ -160,7 +160,7 @@ contract NodeInterface is Initializable, Ownable {
 
     function initialize(uint256 sealedEpoch, address _sfc, address _auth, address _owner) external initializer {
         Ownable.initialize(_owner);
-        auth = NodeInterfaceAuth(_auth);
+        auth = NodeDriverAuth(_auth);
         auth.initialize(_sfc, _owner);
         sfc = SFC(_sfc);
         sfc.initialize(sealedEpoch, address(this), _owner);

--- a/contracts/sfc/NodeInterface.sol
+++ b/contracts/sfc/NodeInterface.sol
@@ -10,6 +10,7 @@ interface NodeInterface {
 //    event SetStorage(address indexed acc, uint256 key, uint256 value);
 
     event UpdatedValidatorWeight(uint256 indexed validatorID, uint256 weight);
+    event UpdatedValidatorPubkey(uint256 indexed validatorID, bytes pubey);
 
     event UpdatedGasPowerAllocationRate(uint256 short, uint256 long);
     event UpdatedMinGasPrice(uint256 minGasPrice);

--- a/contracts/sfc/NodeInterface.sol
+++ b/contracts/sfc/NodeInterface.sol
@@ -1,21 +1,188 @@
 pragma solidity ^0.5.0;
 
-interface NodeInterface {
+import "./SFC.sol";
+
+contract NodeInterfaceAuth is Initializable {
+    address public sfc;
+    address public owner;
+
+    function initialize(address _sfc, address _owner) external initializer {
+        owner = _owner;
+        sfc = _sfc;
+    }
+
+    function authorizeIncBalance(address sender, address acc, uint256 /*diff*/) external {
+        silenceMutabilityWarning();
+        require(sender == sfc, "caller is not the SFC contract");
+        require(acc == sfc, "recipient is not the SFC contract");
+    }
+
+    function authorizeSetBalance(address /*sender*/, address /*acc*/, uint256 /*value*/) external {
+        silenceMutabilityWarning();
+        revert("method is disabled");
+    }
+
+    function authorizeSubBalance(address /*sender*/, address /*acc*/, uint256 /*diff*/) external {
+        silenceMutabilityWarning();
+        revert("method is disabled");
+    }
+
+    function authorizeSetCode(address /*sender*/, address /*acc*/, address /*from*/) external {
+        silenceMutabilityWarning();
+        revert("method is disabled");
+    }
+
+    function authorizeSwapCode(address /*sender*/, address /*acc*/, address /*with*/) external {
+        silenceMutabilityWarning();
+        revert("method is disabled");
+    }
+
+    function authorizeSetStorage(address /*sender*/, address /*acc*/, uint256 /*key*/, uint256 /*value*/) external {
+        silenceMutabilityWarning();
+        revert("method is disabled");
+    }
+
+    function authorizeUpdateGasPowerAllocationRate(address sender, uint256 short, uint256 long) external {
+        silenceMutabilityWarning();
+        require(sender == owner, "caller is not the owner");
+        require(long <= 280000000, "too large long gas power allocation rate");
+        require(short <= 280000000 * 5, "too large short gas power allocation rate");
+        require(long >= 280000, "too small long gas power allocation rate");
+        require(short >= 280000 * 5, "too small short gas power allocation rate");
+    }
+
+    function authorizeUpdateMinGasPrice(address sender, uint256 value) external {
+        silenceMutabilityWarning();
+        require(sender == owner, "caller is not the owner");
+        require(value <= 32.967977168935185184 * 1e18, "too large reward per second");
+    }
+
+    function authorizeUpdateValidatorWeight(address sender, uint256 /*validatorID*/, uint256 /*value*/) external {
+        silenceMutabilityWarning();
+        require(sender == sfc, "caller is not the SFC contract");
+    }
+
+    function authorizeUpdateValidatorPubkey(address sender, uint256 /*validatorID*/, bytes calldata /*pubkey*/) external {
+        silenceMutabilityWarning();
+        require(sender == sfc, "caller is not the SFC contract");
+    }
+
+    function silenceMutabilityWarning() internal {
+        if (false) {
+            address(0).transfer(1);
+        }
+    }
+}
+
+contract NodeInterface is Initializable, Ownable {
+
+    NodeInterfaceAuth internal auth;
+
+    SFC internal sfc;
+
+    function setAuth(address _auth) external onlyOwner {
+        auth = NodeInterfaceAuth(_auth);
+    }
+
+    function setSFC(address _sfc) external onlyOwner {
+        sfc = SFC(_sfc);
+    }
 
     event IncBalance(address indexed acc, uint256 value);
-//    event SetBalance(address indexed acc, uint256 value);
-//    event SubBalance(address indexed acc, uint256 value);
-//    event SetCode(address indexed acc, address indexed from);
-//    event SwapCode(address indexed acc, address indexed with);
-//    event SetStorage(address indexed acc, uint256 key, uint256 value);
+    event SetBalance(address indexed acc, uint256 value);
+    event SubBalance(address indexed acc, uint256 value);
+    event SetCode(address indexed acc, address indexed from);
+    event SwapCode(address indexed acc, address indexed with);
+    event SetStorage(address indexed acc, uint256 key, uint256 value);
 
-    event UpdatedValidatorWeight(uint256 indexed validatorID, uint256 weight);
-    event UpdatedValidatorPubkey(uint256 indexed validatorID, bytes pubey);
+    event UpdateValidatorWeight(uint256 indexed validatorID, uint256 weight);
+    event UpdateValidatorPubkey(uint256 indexed validatorID, bytes pubkey);
 
-    event UpdatedGasPowerAllocationRate(uint256 short, uint256 long);
-    event UpdatedMinGasPrice(uint256 minGasPrice);
+    event UpdateGasPowerAllocationRate(uint256 short, uint256 long);
+    event UpdateMinGasPrice(uint256 minGasPrice);
 
-    function _deactivateValidator(uint256 validatorID, uint256 status) external;
-    function _sealEpochValidators(uint256[] calldata nextValidatorIDs) external;
-    function _sealEpoch(uint256[] calldata offlineTimes, uint256[] calldata offlineBlocks, uint256[] calldata uptimes, uint256[] calldata originatedTxsFee) external;
+    function incBalance(address acc, uint256 diff) external {
+        auth.authorizeIncBalance(msg.sender, acc, diff);
+        emit IncBalance(acc, diff);
+    }
+
+    function setBalance(address acc, uint256 value) external {
+        auth.authorizeSetBalance(msg.sender, acc, value);
+        emit SetBalance(acc, value);
+    }
+
+    function subBalance(address acc, uint256 diff) external {
+        auth.authorizeSubBalance(msg.sender, acc, diff);
+        emit SubBalance(acc, diff);
+    }
+
+    function setCode(address acc, address from) external {
+        auth.authorizeSetCode(msg.sender, acc, from);
+        emit SetCode(acc, from);
+    }
+
+    function swapCode(address acc, address with) external {
+        auth.authorizeSwapCode(msg.sender, acc, with);
+        emit SwapCode(acc, with);
+    }
+
+    function setStorage(address acc, uint256 key, uint256 value) external {
+        auth.authorizeSetStorage(msg.sender, acc, key, value);
+        emit SetStorage(acc, key, value);
+    }
+
+    function updateGasPowerAllocationRate(uint256 short, uint256 long) external {
+        auth.authorizeUpdateGasPowerAllocationRate(msg.sender, short, long);
+        emit UpdateGasPowerAllocationRate(short, long);
+    }
+
+    function updateMinGasPrice(uint256 value) external {
+        auth.authorizeUpdateMinGasPrice(msg.sender, value);
+        emit UpdateMinGasPrice(value);
+    }
+
+    function updateValidatorWeight(uint256 validatorID, uint256 value) external {
+        auth.authorizeUpdateValidatorWeight(msg.sender, validatorID, value);
+        emit UpdateValidatorWeight(validatorID, value);
+    }
+
+    function updateValidatorPubkey(uint256 validatorID, bytes calldata pubkey) external {
+        auth.authorizeUpdateValidatorPubkey(msg.sender, validatorID, pubkey);
+        emit UpdateValidatorPubkey(validatorID, pubkey);
+    }
+
+    modifier onlyNode() {
+        require(msg.sender == address(0), "not callable");
+        _;
+    }
+
+    // Methods which are called only by the node
+
+    function initialize(uint256 sealedEpoch, address _sfc, address _auth, address _owner) external initializer {
+        Ownable.initialize(_owner);
+        auth = NodeInterfaceAuth(_auth);
+        auth.initialize(_sfc, _owner);
+        sfc = SFC(_sfc);
+        sfc.initialize(sealedEpoch, address(this), _owner);
+    }
+
+    function setGenesisValidator(address _auth, uint256 validatorID, bytes calldata pubkey, uint256 status, uint256 createdEpoch, uint256 createdTime, uint256 deactivatedEpoch, uint256 deactivatedTime) external onlyNode {
+        sfc._setGenesisValidator(_auth, validatorID, pubkey, status, createdEpoch, createdTime, deactivatedEpoch, deactivatedTime);
+    }
+
+    function setGenesisDelegation(address delegator, uint256 toValidatorID, uint256 amount, uint256 rewards) external onlyNode {
+        sfc._setGenesisDelegation(delegator, toValidatorID, amount, rewards);
+    }
+
+    function deactivateValidator(uint256 validatorID, uint256 status) external onlyNode {
+        sfc._deactivateValidator(validatorID, status);
+    }
+
+    function sealEpochValidators(uint256[] calldata nextValidatorIDs) external onlyNode {
+        sfc._sealEpochValidators(nextValidatorIDs);
+    }
+
+    function sealEpoch(uint256[] calldata offlineTimes, uint256[] calldata offlineBlocks, uint256[] calldata uptimes, uint256[] calldata originatedTxsFee) external onlyNode {
+        sfc._sealEpoch(offlineTimes, offlineBlocks, uptimes, originatedTxsFee);
+    }
 }

--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -128,6 +128,7 @@ contract SFC is Initializable, Ownable, StakersConstants, Version {
     function _setGenesisDelegation(address delegator, uint256 toValidatorID, uint256 stake, uint256 lockedStake, uint256 lockupFromEpoch, uint256 lockupEndTime, uint256 lockupDuration, uint256 earlyUnlockPenalty, uint256 rewards) external onlyDriver {
         _rawDelegate(delegator, toValidatorID, stake);
         rewardsStash[delegator][toValidatorID] = rewards;
+        _mintNativeToken(stake);
         if (lockedStake != 0) {
             require(lockedStake <= stake, "locked stake is greater than the whole stake");
             LockedDelegation storage ld = getLockupInfo[delegator][toValidatorID];

--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -4,7 +4,7 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 import "./StakerConstants.sol";
 import "../ownership/Ownable.sol";
 import "../version/Version.sol";
-import "./NodeInterface.sol";
+import "./NodeDriver.sol";
 
 /**
  * @dev Stakers contract defines data structure and methods for validators / validators.
@@ -27,7 +27,7 @@ contract SFC is Initializable, Ownable, StakersConstants, Version {
         address auth;
     }
 
-    NodeInterface public node;
+    NodeDriver public node;
 
     uint256 public currentSealedEpoch;
     mapping(uint256 => Validator) public getValidator;
@@ -85,7 +85,7 @@ contract SFC is Initializable, Ownable, StakersConstants, Version {
     }
 
     modifier onlyNode() {
-        require(isNode(msg.sender), "caller is not the NodeInterface contract");
+        require(isNode(msg.sender), "caller is not the NodeDriver contract");
         _;
     }
 
@@ -101,10 +101,10 @@ contract SFC is Initializable, Ownable, StakersConstants, Version {
     Constructor
     */
 
-    function initialize(uint256 sealedEpoch, address nodeInterface, address owner) external initializer {
+    function initialize(uint256 sealedEpoch, address nodeDriver, address owner) external initializer {
         Ownable.initialize(owner);
         currentSealedEpoch = sealedEpoch;
-        node = NodeInterface(nodeInterface);
+        node = NodeDriver(nodeDriver);
     }
 
     function _setGenesisValidator(address auth, uint256 validatorID, bytes calldata pubkey, uint256 status, uint256 createdEpoch, uint256 createdTime, uint256 deactivatedEpoch, uint256 deactivatedTime) external onlyNode {

--- a/contracts/test/UnitTestSFC.sol
+++ b/contracts/test/UnitTestSFC.sol
@@ -8,14 +8,6 @@ contract UnitTestSFC is SFC {
         return 0.3175000 * 1e18;
     }
 
-    function _sealEpoch(uint256[] calldata offlineTimes, uint256[] calldata offlineBlocks, uint256[] calldata uptimes, uint256[] calldata originatedTxsFee) external {
-        __sealEpoch(offlineTimes, offlineBlocks, uptimes, originatedTxsFee);
-    }
-
-    function _sealEpochValidators(uint256[] calldata nextValidatorIDs) external {
-        __sealEpochValidators(nextValidatorIDs);
-    }
-
     uint256 public time;
 
     function rebaseTime() external {
@@ -26,7 +18,7 @@ contract UnitTestSFC is SFC {
         time += diff;
     }
 
-    function _now() internal view returns(uint256) {
+    function _now() internal view returns (uint256) {
         return time;
     }
 
@@ -40,6 +32,23 @@ contract UnitTestSFC is SFC {
 
     function highestLockupEpoch(address delegator, uint256 validatorID) external view returns (uint256) {
         return _highestLockupEpoch(delegator, validatorID);
+    }
+
+    bool public allowedNonNodeCalls;
+
+    function enableNonNodeCalls() external {
+        allowedNonNodeCalls = true;
+    }
+
+    function disableNonNodeCalls() external {
+        allowedNonNodeCalls = false;
+    }
+
+    function isNode(address addr) internal view returns (bool) {
+        if (allowedNonNodeCalls) {
+            return true;
+        }
+        return SFC.isNode(addr);
     }
 }
 

--- a/contracts/test/UnitTestSFC.sol
+++ b/contracts/test/UnitTestSFC.sol
@@ -4,8 +4,8 @@ import "../sfc/SFC.sol";
 
 contract UnitTestSFC is SFC {
     function minSelfStake() public pure returns (uint256) {
-        // 3.175000 FTM
-        return 3.175000 * 1e18;
+        // 0.3175000 FTM
+        return 0.3175000 * 1e18;
     }
 
     function _sealEpoch(uint256[] calldata offlineTimes, uint256[] calldata offlineBlocks, uint256[] calldata uptimes, uint256[] calldata originatedTxsFee) external {
@@ -31,9 +31,16 @@ contract UnitTestSFC is SFC {
     }
 
     function getTime() external view returns (uint256) {
+        return time;
+    }
+
+    function getBlockTime() external view returns (uint256) {
         return SFC._now();
     }
 
+    function highestLockupEpoch(address delegator, uint256 validatorID) external view returns (uint256) {
+        return _highestLockupEpoch(delegator, validatorID);
+    }
 }
 
 

--- a/test/SFC.js
+++ b/test/SFC.js
@@ -267,7 +267,7 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator]) => {
                     from: secondValidator,
                     value: amount18('10'),
                 });
-                (await this.sfc.stake(1, { from: secondValidator, value: 1 }));
+                (await this.sfc.delegate(1, { from: secondValidator, value: 1 }));
             });
 
             it('Should reject if amount is insufficient for self-stake', async () => {
@@ -401,7 +401,7 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
         });
 
         it('Should not be able to stake if Validator not created yet', async () => {
-            await expect(this.sfc.stake(1, {
+            await expect(this.sfc.delegate(1, {
                 from: firstDelegator,
                 value: amount18('10'),
             })).to.be.rejectedWith('Returned error: VM Exception while processing transaction: revert validator doesn\'t exist -- Reason given: validator doesn\'t exist');
@@ -410,7 +410,7 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
                 value: amount18('10'),
             })).to.be.fulfilled;
 
-            await expect(this.sfc.stake(2, {
+            await expect(this.sfc.delegate(2, {
                 from: secondDelegator,
                 value: amount18('10'),
             })).to.be.rejectedWith('Returned error: VM Exception while processing transaction: revert validator doesn\'t exist -- Reason given: validator doesn\'t exist');
@@ -419,7 +419,7 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
                 value: amount18('15'),
             })).to.be.fulfilled;
 
-            await expect(this.sfc.stake(3, {
+            await expect(this.sfc.delegate(3, {
                 from: thirdDelegator,
                 value: amount18('10'),
             })).to.be.rejectedWith('Returned error: VM Exception while processing transaction: revert validator doesn\'t exist -- Reason given: validator doesn\'t exist');
@@ -434,20 +434,20 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
                 from: firstValidator,
                 value: amount18('10'),
             })).to.be.fulfilled;
-            expect(await this.sfc.stake(1, { from: firstDelegator, value: amount18('11') }));
+            expect(await this.sfc.delegate(1, { from: firstDelegator, value: amount18('11') }));
 
             await expect(this.sfc.createValidator(pubkey, {
                 from: secondValidator,
                 value: amount18('15'),
             })).to.be.fulfilled;
-            expect(await this.sfc.stake(2, { from: secondDelegator, value: amount18('10') }));
+            expect(await this.sfc.delegate(2, { from: secondDelegator, value: amount18('10') }));
 
             await expect(this.sfc.createValidator(pubkey, {
                 from: thirdValidator,
                 value: amount18('20'),
             })).to.be.fulfilled;
-            expect(await this.sfc.stake(3, { from: thirdDelegator, value: amount18('10') }));
-            expect(await this.sfc.stake(1, { from: firstDelegator, value: amount18('10') }));
+            expect(await this.sfc.delegate(3, { from: thirdDelegator, value: amount18('10') }));
+            expect(await this.sfc.delegate(1, { from: firstDelegator, value: amount18('10') }));
         });
 
         it('Should return the amount of delegated for each Delegator', async () => {
@@ -455,14 +455,14 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
                 from: firstValidator,
                 value: amount18('10'),
             })).to.be.fulfilled;
-            await this.sfc.stake(1, { from: firstDelegator, value: amount18('11') });
+            await this.sfc.delegate(1, { from: firstDelegator, value: amount18('11') });
             expect((await this.sfc.getStake(firstDelegator, await this.sfc.getValidatorID(firstValidator))).toString()).to.equals('11000000000000000000');
 
             await expect(this.sfc.createValidator(pubkey, {
                 from: secondValidator,
                 value: amount18('15'),
             })).to.be.fulfilled;
-            await this.sfc.stake(2, { from: secondDelegator, value: amount18('10') });
+            await this.sfc.delegate(2, { from: secondDelegator, value: amount18('10') });
             expect((await this.sfc.getStake(secondDelegator, await this.sfc.getValidatorID(firstValidator))).toString()).to.equals('0');
             expect((await this.sfc.getStake(secondDelegator, await this.sfc.getValidatorID(secondValidator))).toString()).to.equals('10000000000000000000');
 
@@ -471,14 +471,14 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
                 from: thirdValidator,
                 value: amount18('12'),
             })).to.be.fulfilled;
-            await this.sfc.stake(3, { from: thirdDelegator, value: amount18('10') });
+            await this.sfc.delegate(3, { from: thirdDelegator, value: amount18('10') });
             expect((await this.sfc.getStake(thirdDelegator, await this.sfc.getValidatorID(thirdValidator))).toString()).to.equals('10000000000000000000');
 
-            await this.sfc.stake(3, { from: firstDelegator, value: amount18('10') });
+            await this.sfc.delegate(3, { from: firstDelegator, value: amount18('10') });
 
             expect((await this.sfc.getStake(thirdDelegator, await this.sfc.getValidatorID(firstValidator))).toString()).to.equals('0');
             expect((await this.sfc.getStake(firstDelegator, await this.sfc.getValidatorID(thirdValidator))).toString()).to.equals('10000000000000000000');
-            await this.sfc.stake(3, { from: firstDelegator, value: amount18('1') });
+            await this.sfc.delegate(3, { from: firstDelegator, value: amount18('1') });
             expect((await this.sfc.getStake(firstDelegator, await this.sfc.getValidatorID(thirdValidator))).toString()).to.equals('11000000000000000000');
         });
 
@@ -487,9 +487,9 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
                 from: firstValidator,
                 value: amount18('10'),
             })).to.be.fulfilled;
-            await this.sfc.stake(1, { from: firstDelegator, value: amount18('11') });
-            await this.sfc.stake(1, { from: secondDelegator, value: amount18('8') });
-            await this.sfc.stake(1, { from: thirdDelegator, value: amount18('8') });
+            await this.sfc.delegate(1, { from: firstDelegator, value: amount18('11') });
+            await this.sfc.delegate(1, { from: secondDelegator, value: amount18('8') });
+            await this.sfc.delegate(1, { from: thirdDelegator, value: amount18('8') });
             const validator = await this.sfc.getValidator(1);
 
             expect(validator.receivedStake.toString()).to.equals('37000000000000000000');
@@ -500,9 +500,9 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
                 from: firstValidator,
                 value: amount18('10'),
             })).to.be.fulfilled;
-            await this.sfc.stake(1, { from: firstDelegator, value: amount18('11') });
-            await this.sfc.stake(1, { from: secondDelegator, value: amount18('8') });
-            await this.sfc.stake(1, { from: thirdDelegator, value: amount18('8') });
+            await this.sfc.delegate(1, { from: firstDelegator, value: amount18('11') });
+            await this.sfc.delegate(1, { from: secondDelegator, value: amount18('8') });
+            await this.sfc.delegate(1, { from: thirdDelegator, value: amount18('8') });
             const validator = await this.sfc.getValidator(1);
 
             expect(validator.receivedStake.toString()).to.equals('37000000000000000000');
@@ -525,9 +525,9 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
             await this.sfc.rebaseTime();
             this.node = new BlockchainNode(this.sfc, firstValidator);
             await expect(this.sfc.createValidator(pubkey, { from: firstValidator, value: amount18('10') })).to.be.fulfilled;
-            await this.sfc.stake(1, { from: firstDelegator, value: amount18('11') });
-            await this.sfc.stake(1, { from: secondDelegator, value: amount18('8') });
-            await this.sfc.stake(1, { from: thirdDelegator, value: amount18('8') });
+            await this.sfc.delegate(1, { from: firstDelegator, value: amount18('11') });
+            await this.sfc.delegate(1, { from: secondDelegator, value: amount18('8') });
+            await this.sfc.delegate(1, { from: thirdDelegator, value: amount18('8') });
             validator = await this.sfc.getValidator(1);
         });
 
@@ -569,9 +569,9 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
             await this.sfc.rebaseTime();
             this.node = new BlockchainNode(this.sfc, firstValidator);
             await expect(this.sfc.createValidator(pubkey, { from: firstValidator, value: amount18('10') })).to.be.fulfilled;
-            await this.sfc.stake(1, { from: firstDelegator, value: amount18('11') });
-            await this.sfc.stake(1, { from: secondDelegator, value: amount18('8') });
-            await this.sfc.stake(1, { from: thirdDelegator, value: amount18('8') });
+            await this.sfc.delegate(1, { from: firstDelegator, value: amount18('11') });
+            await this.sfc.delegate(1, { from: secondDelegator, value: amount18('8') });
+            await this.sfc.delegate(1, { from: thirdDelegator, value: amount18('8') });
             validator = await this.sfc.getValidator(1);
         });
 
@@ -690,7 +690,7 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
             const firstValidatorObj = await this.sfc.getValidator.call(firstValidatorID);
             const secondValidatorObj = await this.sfc.getValidator.call(secondValidatorID);
 
-            await this.node.handle(await this.sfc.stake(firstValidatorID, {
+            await this.node.handle(await this.sfc.delegate(firstValidatorID, {
                 from: firstValidator,
                 value: amount18('0.1'),
             }));
@@ -739,16 +739,16 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
             value: amount18('0.8'),
         });
         thirdValidatorID = await this.sfc.getValidatorID(thirdValidator);
-        await this.sfc.stake(firstValidatorID, {
+        await this.sfc.delegate(firstValidatorID, {
             from: firstValidator,
             value: amount18('0.4'),
         });
 
-        await this.sfc.stake(firstValidatorID, {
+        await this.sfc.delegate(firstValidatorID, {
             from: firstDelegator,
             value: amount18('0.4'),
         });
-        await this.sfc.stake(secondValidatorID, {
+        await this.sfc.delegate(secondValidatorID, {
             from: secondDelegator,
             value: amount18('0.4'),
         });
@@ -1053,7 +1053,7 @@ contract('SFC', async ([firstValidator, firstDelegator]) => {
         this.sfc = await UnitTestSFC.new();
         await this.sfc._setGenesisValidator(firstValidator, 1, pubkey, 0, await this.sfc.currentEpoch(), Date.now(), 0, 0);
         firstValidatorID = await this.sfc.getValidatorID(firstValidator);
-        await this.sfc.stake(firstValidatorID, {
+        await this.sfc.delegate(firstValidatorID, {
             from: firstValidator,
             value: amount18('4'),
         });

--- a/test/SFC.js
+++ b/test/SFC.js
@@ -15,6 +15,7 @@ const SFC = artifacts.require('SFC');
 const StakersConstants = artifacts.require('StakersConstants');
 const NodeDriverAuth = artifacts.require('NodeDriverAuth');
 const NodeDriver = artifacts.require('NodeDriver');
+const NetworkInitializer = artifacts.require('NetworkInitializer');
 
 function amount18(n) {
     return new BN(web3.utils.toWei(n, 'ether'));
@@ -131,9 +132,10 @@ contract('SFC', async () => {
 contract('SFC', async ([account1]) => {
     beforeEach(async () => {
         this.sfc = await UnitTestSFC.new();
-        this.nodeIAuth = await NodeDriverAuth.new();
-        this.nodeI = await NodeDriver.new();
-        await this.nodeI.initialize(12, this.sfc.address, this.nodeIAuth.address, account1);
+        const nodeIRaw = await NodeDriver.new();
+        this.nodeI = await NodeDriverAuth.new();
+        const initializer = await NetworkInitializer.new();
+        await initializer.initializeAll(12, 0, this.sfc.address, this.nodeI.address, nodeIRaw.address, account1);
     });
 
     describe('Genesis Validator', () => {
@@ -164,9 +166,10 @@ contract('SFC', async ([account1]) => {
 contract('SFC', async ([firstValidator, secondValidator, thirdValidator]) => {
     beforeEach(async () => {
         this.sfc = await UnitTestSFC.new();
-        this.nodeIAuth = await NodeDriverAuth.new();
-        this.nodeI = await NodeDriver.new();
-        await this.nodeI.initialize(0, this.sfc.address, this.nodeIAuth.address, firstValidator);
+        const nodeIRaw = await NodeDriver.new();
+        this.nodeI = await NodeDriverAuth.new();
+        const initializer = await NetworkInitializer.new();
+        await initializer.initializeAll(0, 0, this.sfc.address, this.nodeI.address, nodeIRaw.address, firstValidator);
         await this.sfc.rebaseTime();
         this.node = new BlockchainNode(this.sfc, firstValidator);
     });
@@ -326,16 +329,12 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator]) => {
         });
 
         describe('Events emitters', () => {
-            it('Should call updateGasPowerallocationRate', async () => {
-                await this.nodeI.updateGasPowerAllocationRate(280000 * 5, 280000);
+            it('Should call updateRules', async () => {
+                await this.nodeI.updateRules('0x7b22446167223a7b224d6178506172656e7473223a357d2c2245636f6e6f6d79223a7b22426c6f636b4d6973736564536c61636b223a377d2c22426c6f636b73223a7b22426c6f636b476173486172644c696d6974223a313030307d7d');
             });
 
             it('Should call updateOfflinePenaltyThreshold', async () => {
                 await this.sfc._updateOfflinePenaltyThreshold(1, 10);
-            });
-
-            it('Should call updateMinGasPrice', async () => {
-                await this.nodeI.updateMinGasPrice(10);
             });
         });
     });
@@ -344,9 +343,10 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator]) => {
 contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDelegator, secondDelegator, thirdDelegator]) => {
     beforeEach(async () => {
         this.sfc = await UnitTestSFC.new();
-        this.nodeIAuth = await NodeDriverAuth.new();
-        this.nodeI = await NodeDriver.new();
-        await this.nodeI.initialize(10, this.sfc.address, this.nodeIAuth.address, firstValidator);
+        const nodeIRaw = await NodeDriver.new();
+        this.nodeI = await NodeDriverAuth.new();
+        const initializer = await NetworkInitializer.new();
+        await initializer.initializeAll(10, 0, this.sfc.address, this.nodeI.address, nodeIRaw.address, firstValidator);
         await this.sfc.rebaseTime();
         this.node = new BlockchainNode(this.sfc, firstValidator);
     });
@@ -357,7 +357,7 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
         });
 
         it('Should not be possible add a Genesis Delegation if called not by node', async () => {
-            await expect(this.sfc._setGenesisDelegation(firstDelegator, 1, 100, 1000)).to.be.rejectedWith('caller is not the NodeDriver contract');
+            await expect(this.sfc._setGenesisDelegation(firstDelegator, 1, 100, 0, 0, 0, 0, 0, 1000)).to.be.rejectedWith('caller is not the NodeDriver contract');
         });
     });
 
@@ -512,9 +512,10 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
         let validator;
         beforeEach(async () => {
             this.sfc = await UnitTestSFC.new();
-            this.nodeIAuth = await NodeDriverAuth.new();
-            this.nodeI = await NodeDriver.new();
-            await this.nodeI.initialize(12, this.sfc.address, this.nodeIAuth.address, firstValidator);
+            const nodeIRaw = await NodeDriver.new();
+            this.nodeI = await NodeDriverAuth.new();
+            const initializer = await NetworkInitializer.new();
+            await initializer.initializeAll(12, 0, this.sfc.address, this.nodeI.address, nodeIRaw.address, firstValidator);
             await this.sfc.rebaseTime();
             await this.sfc.enableNonNodeCalls();
             this.node = new BlockchainNode(this.sfc, firstValidator);
@@ -559,9 +560,10 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
         let validator;
         beforeEach(async () => {
             this.sfc = await UnitTestSFC.new();
-            this.nodeIAuth = await NodeDriverAuth.new();
-            this.nodeI = await NodeDriver.new();
-            await this.nodeI.initialize(12, this.sfc.address, this.nodeIAuth.address, firstValidator);
+            const nodeIRaw = await NodeDriver.new();
+            this.nodeI = await NodeDriverAuth.new();
+            const initializer = await NetworkInitializer.new();
+            await initializer.initializeAll(12, 0, this.sfc.address, this.nodeI.address, nodeIRaw.address, firstValidator);
             await this.sfc.rebaseTime();
             await this.sfc.enableNonNodeCalls();
             this.node = new BlockchainNode(this.sfc, firstValidator);
@@ -609,9 +611,10 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
     describe('Methods tests', async () => {
         beforeEach(async () => {
             this.sfc = await UnitTestSFC.new();
-            this.nodeIAuth = await NodeDriverAuth.new();
-            this.nodeI = await NodeDriver.new();
-            await this.nodeI.initialize(10, this.sfc.address, this.nodeIAuth.address, firstValidator);
+            const nodeIRaw = await NodeDriver.new();
+            this.nodeI = await NodeDriverAuth.new();
+            const initializer = await NetworkInitializer.new();
+            await initializer.initializeAll(10, 0, this.sfc.address, this.nodeI.address, nodeIRaw.address, firstValidator);
             await this.sfc.rebaseTime();
             await this.sfc.enableNonNodeCalls();
             this.node = new BlockchainNode(this.sfc, firstValidator);
@@ -725,9 +728,10 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
 
     beforeEach(async () => {
         this.sfc = await UnitTestSFC.new();
-        this.nodeIAuth = await NodeDriverAuth.new();
-        this.nodeI = await NodeDriver.new();
-        await this.nodeI.initialize(0, this.sfc.address, this.nodeIAuth.address, firstValidator);
+        const nodeIRaw = await NodeDriver.new();
+        this.nodeI = await NodeDriverAuth.new();
+        const initializer = await NetworkInitializer.new();
+        await initializer.initializeAll(0, 0, this.sfc.address, this.nodeI.address, nodeIRaw.address, firstValidator);
         await this.sfc.rebaseTime();
         await this.sfc.enableNonNodeCalls();
 
@@ -1061,9 +1065,10 @@ contract('SFC', async ([firstValidator, firstDelegator]) => {
 
     beforeEach(async () => {
         this.sfc = await UnitTestSFC.new();
-        this.nodeIAuth = await NodeDriverAuth.new();
-        this.nodeI = await NodeDriver.new();
-        await this.nodeI.initialize(0, this.sfc.address, this.nodeIAuth.address, firstValidator);
+        const nodeIRaw = await NodeDriver.new();
+        this.nodeI = await NodeDriverAuth.new();
+        const initializer = await NetworkInitializer.new();
+        await initializer.initializeAll(0, 0, this.sfc.address, this.nodeI.address, nodeIRaw.address, firstValidator);
         await this.sfc.enableNonNodeCalls();
         await this.sfc._setGenesisValidator(firstValidator, 1, pubkey, 0, await this.sfc.currentEpoch(), Date.now(), 0, 0);
         firstValidatorID = await this.sfc.getValidatorID(firstValidator);
@@ -1076,7 +1081,7 @@ contract('SFC', async ([firstValidator, firstDelegator]) => {
 
     describe('Staking / Sealed Epoch functions', () => {
         it('Should setGenesisDelegation Validator', async () => {
-            await this.sfc._setGenesisDelegation(firstDelegator, firstValidatorID, amount18('1'), 100);
+            await this.sfc._setGenesisDelegation(firstDelegator, firstValidatorID, amount18('1'), 0, 0, 0, 0, 0, 100);
             expect(await this.sfc.getStake(firstDelegator, firstValidatorID)).to.bignumber.equals(amount18('1'));
         });
     });

--- a/test/SFC.js
+++ b/test/SFC.js
@@ -144,7 +144,7 @@ contract('SFC', async ([account1]) => {
         });
 
         it('Set Genesis Validator with bad Status', async () => {
-            await expect(this.sfc._syncValidator(1)).to.be.fulfilled;
+            await expect(this.sfc._syncValidator(1, false)).to.be.fulfilled;
         });
 
         it('should reject sealEpoch if not called by Node', async () => {

--- a/test/SFC.js
+++ b/test/SFC.js
@@ -13,8 +13,8 @@ chai.use(chaiAsPromised);
 const UnitTestSFC = artifacts.require('UnitTestSFC');
 const SFC = artifacts.require('SFC');
 const StakersConstants = artifacts.require('StakersConstants');
-const NodeInterfaceAuth = artifacts.require('NodeInterfaceAuth');
-const NodeInterface = artifacts.require('NodeInterface');
+const NodeDriverAuth = artifacts.require('NodeDriverAuth');
+const NodeDriver = artifacts.require('NodeDriver');
 
 function amount18(n) {
     return new BN(web3.utils.toWei(n, 'ether'));
@@ -131,8 +131,8 @@ contract('SFC', async () => {
 contract('SFC', async ([account1]) => {
     beforeEach(async () => {
         this.sfc = await UnitTestSFC.new();
-        this.nodeIAuth = await NodeInterfaceAuth.new();
-        this.nodeI = await NodeInterface.new();
+        this.nodeIAuth = await NodeDriverAuth.new();
+        this.nodeI = await NodeDriver.new();
         await this.nodeI.initialize(12, this.sfc.address, this.nodeIAuth.address, account1);
     });
 
@@ -150,13 +150,13 @@ contract('SFC', async ([account1]) => {
         it('should reject sealEpoch if not called by Node', async () => {
             await expect(this.sfc._sealEpoch([1], [1], [1], [1], {
                 from: account1,
-            })).to.be.rejectedWith('caller is not the NodeInterface contract');
+            })).to.be.rejectedWith('caller is not the NodeDriver contract');
         });
 
         it('should reject SealEpochValidators if not called by Node', async () => {
             await expect(this.sfc._sealEpochValidators([1], {
                 from: account1,
-            })).to.be.rejectedWith('caller is not the NodeInterface contract');
+            })).to.be.rejectedWith('caller is not the NodeDriver contract');
         });
     });
 });
@@ -164,8 +164,8 @@ contract('SFC', async ([account1]) => {
 contract('SFC', async ([firstValidator, secondValidator, thirdValidator]) => {
     beforeEach(async () => {
         this.sfc = await UnitTestSFC.new();
-        this.nodeIAuth = await NodeInterfaceAuth.new();
-        this.nodeI = await NodeInterface.new();
+        this.nodeIAuth = await NodeDriverAuth.new();
+        this.nodeI = await NodeDriver.new();
         await this.nodeI.initialize(0, this.sfc.address, this.nodeIAuth.address, firstValidator);
         await this.sfc.rebaseTime();
         this.node = new BlockchainNode(this.sfc, firstValidator);
@@ -344,8 +344,8 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator]) => {
 contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDelegator, secondDelegator, thirdDelegator]) => {
     beforeEach(async () => {
         this.sfc = await UnitTestSFC.new();
-        this.nodeIAuth = await NodeInterfaceAuth.new();
-        this.nodeI = await NodeInterface.new();
+        this.nodeIAuth = await NodeDriverAuth.new();
+        this.nodeI = await NodeDriver.new();
         await this.nodeI.initialize(10, this.sfc.address, this.nodeIAuth.address, firstValidator);
         await this.sfc.rebaseTime();
         this.node = new BlockchainNode(this.sfc, firstValidator);
@@ -353,11 +353,11 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
 
     describe('Prevent Genesis Call if not node', () => {
         it('Should not be possible add a Genesis Validator if called not by node', async () => {
-            await expect(this.sfc._setGenesisValidator(secondValidator, 1, pubkey, 0, await this.sfc.currentEpoch(), Date.now(), 0, 0)).to.be.rejectedWith('caller is not the NodeInterface contract');
+            await expect(this.sfc._setGenesisValidator(secondValidator, 1, pubkey, 0, await this.sfc.currentEpoch(), Date.now(), 0, 0)).to.be.rejectedWith('caller is not the NodeDriver contract');
         });
 
         it('Should not be possible add a Genesis Delegation if called not by node', async () => {
-            await expect(this.sfc._setGenesisDelegation(firstDelegator, 1, 100, 1000)).to.be.rejectedWith('caller is not the NodeInterface contract');
+            await expect(this.sfc._setGenesisDelegation(firstDelegator, 1, 100, 1000)).to.be.rejectedWith('caller is not the NodeDriver contract');
         });
     });
 
@@ -512,8 +512,8 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
         let validator;
         beforeEach(async () => {
             this.sfc = await UnitTestSFC.new();
-            this.nodeIAuth = await NodeInterfaceAuth.new();
-            this.nodeI = await NodeInterface.new();
+            this.nodeIAuth = await NodeDriverAuth.new();
+            this.nodeI = await NodeDriver.new();
             await this.nodeI.initialize(12, this.sfc.address, this.nodeIAuth.address, firstValidator);
             await this.sfc.rebaseTime();
             await this.sfc.enableNonNodeCalls();
@@ -559,8 +559,8 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
         let validator;
         beforeEach(async () => {
             this.sfc = await UnitTestSFC.new();
-            this.nodeIAuth = await NodeInterfaceAuth.new();
-            this.nodeI = await NodeInterface.new();
+            this.nodeIAuth = await NodeDriverAuth.new();
+            this.nodeI = await NodeDriver.new();
             await this.nodeI.initialize(12, this.sfc.address, this.nodeIAuth.address, firstValidator);
             await this.sfc.rebaseTime();
             await this.sfc.enableNonNodeCalls();
@@ -609,8 +609,8 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
     describe('Methods tests', async () => {
         beforeEach(async () => {
             this.sfc = await UnitTestSFC.new();
-            this.nodeIAuth = await NodeInterfaceAuth.new();
-            this.nodeI = await NodeInterface.new();
+            this.nodeIAuth = await NodeDriverAuth.new();
+            this.nodeI = await NodeDriver.new();
             await this.nodeI.initialize(10, this.sfc.address, this.nodeIAuth.address, firstValidator);
             await this.sfc.rebaseTime();
             await this.sfc.enableNonNodeCalls();
@@ -725,8 +725,8 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
 
     beforeEach(async () => {
         this.sfc = await UnitTestSFC.new();
-        this.nodeIAuth = await NodeInterfaceAuth.new();
-        this.nodeI = await NodeInterface.new();
+        this.nodeIAuth = await NodeDriverAuth.new();
+        this.nodeI = await NodeDriver.new();
         await this.nodeI.initialize(0, this.sfc.address, this.nodeIAuth.address, firstValidator);
         await this.sfc.rebaseTime();
         await this.sfc.enableNonNodeCalls();
@@ -837,7 +837,7 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
 
         it('Should not be able to deactivate validator if not Node', async () => {
             await this.sfc.disableNonNodeCalls();
-            await expect(this.sfc._deactivateValidator(1, 0)).to.be.rejectedWith('caller is not the NodeInterface contract');
+            await expect(this.sfc._deactivateValidator(1, 0)).to.be.rejectedWith('caller is not the NodeDriver contract');
         });
 
         it('Should seal Epochs', async () => {
@@ -1061,8 +1061,8 @@ contract('SFC', async ([firstValidator, firstDelegator]) => {
 
     beforeEach(async () => {
         this.sfc = await UnitTestSFC.new();
-        this.nodeIAuth = await NodeInterfaceAuth.new();
-        this.nodeI = await NodeInterface.new();
+        this.nodeIAuth = await NodeDriverAuth.new();
+        this.nodeI = await NodeDriver.new();
         await this.nodeI.initialize(0, this.sfc.address, this.nodeIAuth.address, firstValidator);
         await this.sfc.enableNonNodeCalls();
         await this.sfc._setGenesisValidator(firstValidator, 1, pubkey, 0, await this.sfc.currentEpoch(), Date.now(), 0, 0);

--- a/test/SFC.js
+++ b/test/SFC.js
@@ -6,7 +6,7 @@ const {
     balance,
 } = require('openzeppelin-test-helpers');
 const chai = require('chai');
-const { expect } = require('chai');
+const {expect} = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 
 chai.use(chaiAsPromised);
@@ -183,7 +183,7 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator]) => {
             });
 
             it('Returns minimum amount to stake for a Validator', async () => {
-                expect((await this.sfc.minSelfStake()).toString()).to.equals('3175000000000000000');
+                expect((await this.sfc.minSelfStake()).toString()).to.equals('317500000000000000');
             });
 
             it('Returns the maximum ratio of delegations a validator can have', async () => {
@@ -271,10 +271,10 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator]) => {
             });
 
             it('Should reject if amount is insufficient for self-stake', async () => {
-                expect((await this.sfc.minSelfStake()).toString()).to.equals('3175000000000000000');
+                expect((await this.sfc.minSelfStake()).toString()).to.equals('317500000000000000');
                 await expect(this.sfc.createValidator(pubkey, {
                     from: secondValidator,
-                    value: amount18('3'),
+                    value: amount18('0.3'),
                 })).to.be.rejectedWith('Returned error: VM Exception while processing transaction: revert insufficient self-stake -- Reason given: insufficient self-stake.');
             });
 
@@ -288,7 +288,7 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator]) => {
 
             it('Should return Now()', async () => {
                 const now = Math.trunc((Date.now()) / 1000);
-                expect((await this.sfc.getTime()).toNumber()).to.be.within(now - 10, now + 10);
+                expect((await this.sfc.getBlockTime()).toNumber()).to.be.within(now - 10, now + 10);
             });
         });
 
@@ -456,15 +456,15 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
                 value: amount18('10'),
             })).to.be.fulfilled;
             await this.sfc.stake(1, { from: firstDelegator, value: amount18('11') });
-            expect((await this.sfc.getDelegation(firstDelegator, await this.sfc.getValidatorID(firstValidator))).toString()).to.equals('11000000000000000000');
+            expect((await this.sfc.getStake(firstDelegator, await this.sfc.getValidatorID(firstValidator))).toString()).to.equals('11000000000000000000');
 
             await expect(this.sfc.createValidator(pubkey, {
                 from: secondValidator,
                 value: amount18('15'),
             })).to.be.fulfilled;
             await this.sfc.stake(2, { from: secondDelegator, value: amount18('10') });
-            expect((await this.sfc.getDelegation(secondDelegator, await this.sfc.getValidatorID(firstValidator))).toString()).to.equals('0');
-            expect((await this.sfc.getDelegation(secondDelegator, await this.sfc.getValidatorID(secondValidator))).toString()).to.equals('10000000000000000000');
+            expect((await this.sfc.getStake(secondDelegator, await this.sfc.getValidatorID(firstValidator))).toString()).to.equals('0');
+            expect((await this.sfc.getStake(secondDelegator, await this.sfc.getValidatorID(secondValidator))).toString()).to.equals('10000000000000000000');
 
 
             await expect(this.sfc.createValidator(pubkey, {
@@ -472,14 +472,14 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
                 value: amount18('12'),
             })).to.be.fulfilled;
             await this.sfc.stake(3, { from: thirdDelegator, value: amount18('10') });
-            expect((await this.sfc.getDelegation(thirdDelegator, await this.sfc.getValidatorID(thirdValidator))).toString()).to.equals('10000000000000000000');
+            expect((await this.sfc.getStake(thirdDelegator, await this.sfc.getValidatorID(thirdValidator))).toString()).to.equals('10000000000000000000');
 
             await this.sfc.stake(3, { from: firstDelegator, value: amount18('10') });
 
-            expect((await this.sfc.getDelegation(thirdDelegator, await this.sfc.getValidatorID(firstValidator))).toString()).to.equals('0');
-            expect((await this.sfc.getDelegation(firstDelegator, await this.sfc.getValidatorID(thirdValidator))).toString()).to.equals('10000000000000000000');
+            expect((await this.sfc.getStake(thirdDelegator, await this.sfc.getValidatorID(firstValidator))).toString()).to.equals('0');
+            expect((await this.sfc.getStake(firstDelegator, await this.sfc.getValidatorID(thirdValidator))).toString()).to.equals('10000000000000000000');
             await this.sfc.stake(3, { from: firstDelegator, value: amount18('1') });
-            expect((await this.sfc.getDelegation(firstDelegator, await this.sfc.getValidatorID(thirdValidator))).toString()).to.equals('11000000000000000000');
+            expect((await this.sfc.getStake(firstDelegator, await this.sfc.getValidatorID(thirdValidator))).toString()).to.equals('11000000000000000000');
         });
 
         it('Should return the total of received Stake', async () => {
@@ -614,24 +614,24 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
             expect(await this.sfc.lastValidatorID.call()).to.be.bignumber.equal(new BN('0'));
             await expectRevert(this.sfc.createValidator(pubkey, {
                 from: firstValidator,
-                value: amount18('3.175')
+                value: amount18('0.3175')
                     .sub(new BN(1)),
             }), 'insufficient self-stake');
             await this.node.handle(await this.sfc.createValidator(pubkey, {
                 from: firstValidator,
-                value: amount18('3.175'),
+                value: amount18('0.3175'),
             }));
             await expectRevert(this.sfc.createValidator(pubkey, {
                 from: firstValidator,
-                value: amount18('3.175'),
+                value: amount18('0.3175'),
             }), 'validator already exists');
             await this.node.handle(await this.sfc.createValidator(pubkey, {
                 from: secondValidator,
-                value: amount18('5'),
+                value: amount18('0.5'),
             }));
 
             expect(await this.sfc.lastValidatorID.call()).to.be.bignumber.equal(new BN('2'));
-            expect(await this.sfc.totalStake.call()).to.be.bignumber.equal(amount18('8.175'));
+            expect(await this.sfc.totalStake.call()).to.be.bignumber.equal(amount18('0.8175'));
 
             const firstValidatorID = await this.sfc.getValidatorID(firstValidator);
             const secondValidatorID = await this.sfc.getValidatorID(secondValidator);
@@ -645,7 +645,7 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
             const secondValidatorObj = await this.sfc.getValidator.call(secondValidatorID);
 
             // check first validator object
-            expect(firstValidatorObj.receivedStake).to.be.bignumber.equal(amount18('3.175'));
+            expect(firstValidatorObj.receivedStake).to.be.bignumber.equal(amount18('0.3175'));
             expect(firstValidatorObj.createdEpoch).to.be.bignumber.equal(new BN('11'));
             expect(firstValidatorObj.auth).to.equal(firstValidator);
             expect(firstValidatorObj.status).to.be.bignumber.equal(new BN('0'));
@@ -653,7 +653,7 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
             expect(firstValidatorObj.deactivatedEpoch).to.be.bignumber.equal(new BN('0'));
 
             // check second validator object
-            expect(secondValidatorObj.receivedStake).to.be.bignumber.equal(amount18('5'));
+            expect(secondValidatorObj.receivedStake).to.be.bignumber.equal(amount18('0.5'));
             expect(secondValidatorObj.createdEpoch).to.be.bignumber.equal(new BN('11'));
             expect(secondValidatorObj.auth).to.equal(secondValidator);
             expect(secondValidatorObj.status).to.be.bignumber.equal(new BN('0'));
@@ -661,23 +661,23 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
             expect(secondValidatorObj.deactivatedEpoch).to.be.bignumber.equal(new BN('0'));
 
             // check created delegations
-            expect(await this.sfc.getDelegation.call(firstValidator, firstValidatorID)).to.be.bignumber.equal(amount18('3.175'));
-            expect(await this.sfc.getDelegation.call(secondValidator, secondValidatorID)).to.be.bignumber.equal(amount18('5'));
+            expect(await this.sfc.getStake.call(firstValidator, firstValidatorID)).to.be.bignumber.equal(amount18('0.3175'));
+            expect(await this.sfc.getStake.call(secondValidator, secondValidatorID)).to.be.bignumber.equal(amount18('0.5'));
 
             // check fired node-related logs
             expect(Object.keys(this.node.nextValidators).length).to.equal(2);
-            expect(this.node.nextValidators[firstValidatorID.toString()]).to.be.bignumber.equal(amount18('3.175'));
-            expect(this.node.nextValidators[secondValidatorID.toString()]).to.be.bignumber.equal(amount18('5'));
+            expect(this.node.nextValidators[firstValidatorID.toString()]).to.be.bignumber.equal(amount18('0.3175'));
+            expect(this.node.nextValidators[secondValidatorID.toString()]).to.be.bignumber.equal(amount18('0.5'));
         });
 
         it('checking sealing epoch', async () => {
             await this.node.handle(await this.sfc.createValidator(pubkey, {
                 from: firstValidator,
-                value: amount18('3.175'),
+                value: amount18('0.3175'),
             }));
             await this.node.handle(await this.sfc.createValidator(pubkey, {
                 from: secondValidator,
-                value: amount18('6.825'),
+                value: amount18('0.6825'),
             }));
 
             await this.node.sealEpoch(new BN('100'));
@@ -692,27 +692,27 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
 
             await this.node.handle(await this.sfc.stake(firstValidatorID, {
                 from: firstValidator,
-                value: amount18('1'),
+                value: amount18('0.1'),
             }));
             await this.node.handle(await this.sfc.createValidator(pubkey, {
                 from: thirdValidator,
-                value: amount18('4'),
+                value: amount18('0.4'),
             }));
             const thirdValidatorID = await this.sfc.getValidatorID(thirdValidator);
 
             // check fired node-related logs
             expect(Object.keys(this.node.validators).length).to.equal(2);
-            expect(this.node.validators[firstValidatorID.toString()]).to.be.bignumber.equal(amount18('3.175'));
-            expect(this.node.validators[secondValidatorID.toString()]).to.be.bignumber.equal(amount18('6.825'));
+            expect(this.node.validators[firstValidatorID.toString()]).to.be.bignumber.equal(amount18('0.3175'));
+            expect(this.node.validators[secondValidatorID.toString()]).to.be.bignumber.equal(amount18('0.6825'));
             expect(Object.keys(this.node.nextValidators).length).to.equal(3);
-            expect(this.node.nextValidators[firstValidatorID.toString()]).to.be.bignumber.equal(amount18('4.175'));
-            expect(this.node.nextValidators[secondValidatorID.toString()]).to.be.bignumber.equal(amount18('6.825'));
-            expect(this.node.nextValidators[thirdValidatorID.toString()]).to.be.bignumber.equal(amount18('4'));
+            expect(this.node.nextValidators[firstValidatorID.toString()]).to.be.bignumber.equal(amount18('0.4175'));
+            expect(this.node.nextValidators[secondValidatorID.toString()]).to.be.bignumber.equal(amount18('0.6825'));
+            expect(this.node.nextValidators[thirdValidatorID.toString()]).to.be.bignumber.equal(amount18('0.4'));
         });
     });
 });
 
-contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDelegator]) => {
+contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDelegator, secondDelegator]) => {
     let firstValidatorID;
     let secondValidatorID;
     let thirdValidatorID;
@@ -724,29 +724,33 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
 
         await this.sfc.createValidator(pubkey, {
             from: firstValidator,
-            value: amount18('4'),
+            value: amount18('0.4'),
         });
         firstValidatorID = await this.sfc.getValidatorID(firstValidator);
 
         await this.sfc.createValidator(pubkey, {
             from: secondValidator,
-            value: amount18('4'),
+            value: amount18('0.8'),
         });
         secondValidatorID = await this.sfc.getValidatorID(secondValidator);
 
         await this.sfc.createValidator(pubkey, {
             from: thirdValidator,
-            value: amount18('4'),
+            value: amount18('0.8'),
         });
         thirdValidatorID = await this.sfc.getValidatorID(thirdValidator);
         await this.sfc.stake(firstValidatorID, {
             from: firstValidator,
-            value: amount18('4'),
+            value: amount18('0.4'),
         });
 
         await this.sfc.stake(firstValidatorID, {
             from: firstDelegator,
-            value: amount18('4'),
+            value: amount18('0.4'),
+        });
+        await this.sfc.stake(secondValidatorID, {
+            from: secondDelegator,
+            value: amount18('0.4'),
         });
 
         await sealEpoch(this.sfc, (new BN(0)).toString());
@@ -770,20 +774,20 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
 
             await sealEpoch(this.sfc, (new BN(60 * 60 * 24)).toString());
 
-            expect((await this.sfc.pendingRewards(firstValidator, firstValidatorID)).toString()).to.equals('25400');
-            expect((await this.sfc.pendingRewards(firstDelegator, firstValidatorID)).toString()).to.equals('8812');
+            expect((await this.sfc.pendingRewards(firstValidator, firstValidatorID)).toString()).to.equals('3523');
+            expect((await this.sfc.pendingRewards(firstDelegator, firstValidatorID)).toString()).to.equals('1032');
         });
 
         it('Check if pending Rewards have been increased after sealing Epoch', async () => {
             await this.sfc._updateBaseRewardPerSecond(new BN('1'));
 
             await sealEpoch(this.sfc, (new BN(60 * 60 * 24)).toString());
-            expect((await this.sfc.pendingRewards(firstValidator, firstValidatorID)).toString()).to.equals('25400');
-            expect((await this.sfc.pendingRewards(firstDelegator, firstValidatorID)).toString()).to.equals('8812');
+            expect((await this.sfc.pendingRewards(firstValidator, firstValidatorID)).toString()).to.equals('3523');
+            expect((await this.sfc.pendingRewards(firstDelegator, firstValidatorID)).toString()).to.equals('1032');
 
             await sealEpoch(this.sfc, (new BN(60 * 60 * 24)).toString());
-            expect((await this.sfc.pendingRewards(firstValidator, firstValidatorID)).toString()).to.equals('50800');
-            expect((await this.sfc.pendingRewards(firstDelegator, firstValidatorID)).toString()).to.equals('17624');
+            expect((await this.sfc.pendingRewards(firstValidator, firstValidatorID)).toString()).to.equals('7046');
+            expect((await this.sfc.pendingRewards(firstDelegator, firstValidatorID)).toString()).to.equals('2065');
         });
 
         it('Should increase balances after claiming Rewards', async () => {
@@ -809,17 +813,7 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
             expect((await this.sfc.rewardsStash(firstDelegator, 1)).toString()).to.equals('0');
 
             await this.sfc.stashRewards(firstDelegator, 1);
-            expect((await this.sfc.rewardsStash(firstDelegator, 1)).toString()).to.equals('8812');
-        });
-
-        it('Should return validatorMetadata', async () => {
-            await this.sfc._updateBaseRewardPerSecond(new BN('1'));
-
-            await sealEpoch(this.sfc, (new BN(0)).toString());
-            await sealEpoch(this.sfc, (new BN(60 * 60 * 24)).toString());
-
-            expect((await this.sfc.validatorMetadata(1))).to.equals(null);
-            expect((await this.sfc.validatorMetadata(2))).to.equals(null);
+            expect((await this.sfc.rewardsStash(firstDelegator, 1)).toString()).to.equals('1032');
         });
 
         it('Should update the validator on node', async () => {
@@ -902,6 +896,153 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
             await expect(this.sfc._sealEpochValidators(allValidators)).to.be.fulfilled;
         });
     });
+
+    describe('Stake lockup', () => {
+        beforeEach('lock stakes', async () => {
+            // Lock 75% of stake for 60% of a maximum lockup period
+            // Should receive (0.3 * 0.25 + (0.3 + 0.7 * 0.6) * 0.75) / 0.3 = 2.05 times more rewards
+            await this.sfc.lockStake(firstValidatorID, new BN(86400 * 219), amount18('0.6'), {
+                from: firstValidator,
+            });
+            // Lock 25% of stake for 20% of a maximum lockup period
+            // Should receive (0.3 * 0.75 + (0.3 + 0.7 * 0.2) * 0.25) / 0.3 = 1.1166 times more rewards
+            await this.sfc.lockStake(firstValidatorID, new BN(86400 * 73), amount18('0.1'), {
+                from: firstDelegator,
+            });
+        });
+
+        // note: copied from the non-lockup tests
+        it('Check pending Rewards of delegators', async () => {
+            await this.sfc._updateBaseRewardPerSecond(new BN('1'));
+
+            expect((await this.sfc.pendingRewards(firstValidator, firstValidatorID)).toString()).to.equals('0');
+            expect((await this.sfc.pendingRewards(firstDelegator, firstValidatorID)).toString()).to.equals('0');
+
+            await sealEpoch(this.sfc, (new BN(60 * 60 * 24)).toString());
+
+            expect((await this.sfc.pendingRewards(firstValidator, firstValidatorID)).toString()).to.equals('7221');
+            expect((await this.sfc.pendingRewards(firstDelegator, firstValidatorID)).toString()).to.equals('1152');
+        });
+
+        // note: copied from the non-lockup tests
+        it('Check if pending Rewards have been increased after sealing Epoch', async () => {
+            await this.sfc._updateBaseRewardPerSecond(new BN('1'));
+
+            await sealEpoch(this.sfc, (new BN(60 * 60 * 24)).toString());
+            expect((await this.sfc.pendingRewards(firstValidator, firstValidatorID)).toString()).to.equals('7221');
+            expect((await this.sfc.pendingRewards(firstDelegator, firstValidatorID)).toString()).to.equals('1152');
+
+            await sealEpoch(this.sfc, (new BN(60 * 60 * 24)).toString());
+            expect((await this.sfc.pendingRewards(firstValidator, firstValidatorID)).toString()).to.equals('14443');
+            expect((await this.sfc.pendingRewards(firstDelegator, firstValidatorID)).toString()).to.equals('2305');
+        });
+
+        // note: copied from the non-lockup tests
+        it('Should increase balances after claiming Rewards', async () => {
+            await this.sfc._updateBaseRewardPerSecond(new BN('1'));
+
+            await sealEpoch(this.sfc, (new BN(0)).toString());
+            await sealEpoch(this.sfc, (new BN(60 * 60 * 24)).toString());
+
+            const firstDelegatorPendingRewards = await this.sfc.pendingRewards(firstDelegator, firstValidatorID);
+            const firstDelegatorBalance = await web3.eth.getBalance(firstDelegator);
+
+            await this.sfc.claimRewards(1, { from: firstDelegator });
+
+            expect(new BN(firstDelegatorBalance + firstDelegatorPendingRewards)).to.be.bignumber.above(await web3.eth.getBalance(firstDelegator));
+        });
+
+        // note: copied from the non-lockup tests
+        it('Should return stashed Rewards', async () => {
+            await this.sfc._updateBaseRewardPerSecond(new BN('1'));
+
+            await sealEpoch(this.sfc, (new BN(0)).toString());
+            await sealEpoch(this.sfc, (new BN(60 * 60 * 24)).toString());
+
+            expect((await this.sfc.rewardsStash(firstDelegator, 1)).toString()).to.equals('0');
+
+            await this.sfc.stashRewards(firstDelegator, 1);
+            expect((await this.sfc.rewardsStash(firstDelegator, 1)).toString()).to.equals('1152');
+        });
+
+        it('Should return pending rewards after unlocking and re-locking', async () => {
+            await this.sfc._updateBaseRewardPerSecond(new BN('1'));
+
+            for (let i = 0; i < 2; i++) {
+                const epoch = await this.sfc.currentSealedEpoch();
+                // delegator 1 is still locked
+                // delegator 1 should receive more rewards than delegator 2
+                // validator 1 should receive more rewards than validator 2
+                await sealEpoch(this.sfc, (new BN(86400 * (73))).toString());
+
+                expect(await this.sfc.pendingRewards(firstDelegator, 1)).to.be.bignumber.equal(new BN(84185));
+                expect(await this.sfc.pendingRewards(secondDelegator, 2)).to.be.bignumber.equal(new BN(75390));
+                expect(await this.sfc.pendingRewards(firstValidator, 1)).to.be.bignumber.equal(new BN(527290));
+                expect(await this.sfc.pendingRewards(secondValidator, 2)).to.be.bignumber.equal(new BN(257215));
+
+                expect(await this.sfc.highestLockupEpoch(firstDelegator, 1)).to.be.bignumber.equal(epoch.add(new BN(1)));
+                expect(await this.sfc.highestLockupEpoch(secondDelegator, 2)).to.be.bignumber.equal(new BN(0));
+                expect(await this.sfc.highestLockupEpoch(firstValidator, 1)).to.be.bignumber.equal(epoch.add(new BN(1)));
+                expect(await this.sfc.highestLockupEpoch(secondValidator, 2)).to.be.bignumber.equal(new BN(0));
+
+                // delegator 1 isn't locked already
+                // delegator 1 should receive the same reward as delegator 2
+                // validator 1 should receive more rewards than validator 2
+                await sealEpoch(this.sfc, (new BN(86400 * (1))).toString());
+
+                expect(await this.sfc.pendingRewards(firstDelegator, 1)).to.be.bignumber.equal(new BN(84185 + 1032));
+                expect(await this.sfc.pendingRewards(secondDelegator, 2)).to.be.bignumber.equal(new BN(75390 + 1033));
+                expect(await this.sfc.pendingRewards(firstValidator, 1)).to.be.bignumber.equal(new BN(527290 + 7222));
+                expect(await this.sfc.pendingRewards(secondValidator, 2)).to.be.bignumber.equal(new BN(257215 + 3523));
+                expect(await this.sfc.highestLockupEpoch(firstDelegator, 1)).to.be.bignumber.equal(epoch.add(new BN(1)));
+                expect(await this.sfc.highestLockupEpoch(firstValidator, 1)).to.be.bignumber.equal(epoch.add(new BN(2)));
+
+                // validator 1 is still locked
+                // delegator 1 should receive the same reward as delegator 2
+                // validator 1 should receive more rewards than validator 2
+                await sealEpoch(this.sfc, (new BN(86400 * (145))).toString());
+
+                expect(await this.sfc.pendingRewards(firstDelegator, 1)).to.be.bignumber.equal(new BN(84185 + 1032 + 149749));
+                expect(await this.sfc.pendingRewards(secondDelegator, 2)).to.be.bignumber.equal(new BN(75390 + 1033 + 149749));
+                expect(await this.sfc.pendingRewards(firstValidator, 1)).to.be.bignumber.equal(new BN(527290 + 7222 + 1047359));
+                expect(await this.sfc.pendingRewards(secondValidator, 2)).to.be.bignumber.equal(new BN(257215 + 3523 + 510908));
+                expect(await this.sfc.highestLockupEpoch(firstDelegator, 1)).to.be.bignumber.equal(epoch.add(new BN(1)));
+                expect(await this.sfc.highestLockupEpoch(firstValidator, 1)).to.be.bignumber.equal(epoch.add(new BN(3)));
+
+                // validator 1 isn't locked already
+                // delegator 1 should receive the same reward as delegator 2
+                // validator 1 should receive the same reward as validator 2
+                await sealEpoch(this.sfc, (new BN(86400 * (1))).toString());
+
+                expect(await this.sfc.pendingRewards(firstDelegator, 1)).to.be.bignumber.equal(new BN(84185 + 1032 + 149749 + 1033));
+                expect(await this.sfc.pendingRewards(secondDelegator, 2)).to.be.bignumber.equal(new BN(75390 + 1033 + 149749 + 1032));
+                expect(await this.sfc.pendingRewards(firstValidator, 1)).to.be.bignumber.equal(new BN(527290 + 7222 + 1047359 + 3523));
+                expect(await this.sfc.pendingRewards(secondValidator, 2)).to.be.bignumber.equal(new BN(257215 + 3523 + 510908 + 3523));
+                expect(await this.sfc.highestLockupEpoch(firstDelegator, 1)).to.be.bignumber.equal(epoch.add(new BN(1)));
+                expect(await this.sfc.highestLockupEpoch(firstValidator, 1)).to.be.bignumber.equal(epoch.add(new BN(3)));
+
+                // re-lock both validator and delegator
+                await this.sfc.lockStake(firstValidatorID, new BN(86400 * 219), amount18('0.6'), {
+                    from: firstValidator,
+                });
+                await this.sfc.lockStake(firstValidatorID, new BN(86400 * 73), amount18('0.1'), {
+                    from: firstDelegator,
+                });
+                // check rewards didn't change after re-locking
+                expect(await this.sfc.pendingRewards(firstDelegator, 1)).to.be.bignumber.equal(new BN(84185 + 1032 + 149749 + 1033));
+                expect(await this.sfc.pendingRewards(secondDelegator, 2)).to.be.bignumber.equal(new BN(75390 + 1033 + 149749 + 1032));
+                expect(await this.sfc.pendingRewards(firstValidator, 1)).to.be.bignumber.equal(new BN(527290 + 7222 + 1047359 + 3523));
+                expect(await this.sfc.pendingRewards(secondValidator, 2)).to.be.bignumber.equal(new BN(257215 + 3523 + 510908 + 3523));
+                expect(await this.sfc.highestLockupEpoch(firstDelegator, 1)).to.be.bignumber.equal(new BN(0));
+                expect(await this.sfc.highestLockupEpoch(firstValidator, 1)).to.be.bignumber.equal(new BN(0));
+                // claim rewards to reset pending rewards
+                await this.sfc.claimRewards(1, {from: firstDelegator});
+                await this.sfc.claimRewards(2, {from: secondDelegator});
+                await this.sfc.claimRewards(1, {from: firstValidator});
+                await this.sfc.claimRewards(2, {from: secondValidator});
+            }
+        });
+    });
 });
 
 
@@ -922,7 +1063,7 @@ contract('SFC', async ([firstValidator, firstDelegator]) => {
     describe('Staking / Sealed Epoch functions', () => {
         it('Should setGenesisDelegation Validator', async () => {
             await this.sfc._setGenesisDelegation(firstDelegator, firstValidatorID, amount18('1'), 100);
-            expect(await this.sfc.getDelegation(firstDelegator, firstValidatorID)).to.bignumber.equals(amount18('1'));
+            expect(await this.sfc.getStake(firstDelegator, firstValidatorID)).to.bignumber.equals(amount18('1'));
         });
     });
 });


### PR DESCRIPTION
- add fluid staking economy (stake lockups)
- decouple interaction with the node into the NodeDriver contract
- decouple genesis contract initialization into the NetworkInitializer contract
- rename methods stake -> delegate, unstake -> undelegate
- fix genesis state initialization