### PR TITLE
safemath removal + upgrade 0.8.1 + fix potential errors

### DIFF
--- a/contracts/common/Decimal.sol
+++ b/contracts/common/Decimal.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.1;
 
 library Decimal {
     // unit is used for decimals, e.g. 0.123456

--- a/contracts/common/Initializable.sol
+++ b/contracts/common/Initializable.sol
@@ -1,4 +1,5 @@
-pragma solidity >=0.4.24 <0.7.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.1;
 
 
 /**

--- a/contracts/common/ReentrancyGuard.sol
+++ b/contracts/common/ReentrancyGuard.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.1;
 import "./Initializable.sol";
 
 /**

--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.1;
 
 import "../common/Initializable.sol";
 

--- a/contracts/sfc/Migrations.sol
+++ b/contracts/sfc/Migrations.sol
@@ -1,10 +1,11 @@
-pragma solidity >=0.4.21 <0.6.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.1;
 
 contract Migrations {
   address public owner;
   uint public last_completed_migration;
 
-  constructor() public {
+  constructor() {
     owner = msg.sender;
   }
 

--- a/contracts/sfc/NetworkInitializer.sol
+++ b/contracts/sfc/NetworkInitializer.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.1;
 
 import "./SFC.sol";
 import "./NodeDriver.sol";
@@ -9,6 +10,6 @@ contract NetworkInitializer {
         NodeDriver(_driver).initialize(_auth, _evmWriter);
         NodeDriverAuth(_auth).initialize(_sfc, _driver, _owner);
         SFC(_sfc).initialize(sealedEpoch, totalSupply, _auth, _owner);
-        selfdestruct(address(0));
+        selfdestruct(payable(0));
     }
 }

--- a/contracts/sfc/NodeDriver.sol
+++ b/contracts/sfc/NodeDriver.sol
@@ -1,12 +1,11 @@
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.1;
 
-import "@openzeppelin/contracts/math/SafeMath.sol";
 import "../common/Initializable.sol";
 import "../ownership/Ownable.sol";
 import "./SFC.sol";
 
 contract NodeDriverAuth is Initializable, Ownable {
-    using SafeMath for uint256;
 
     SFC internal sfc;
     NodeDriver internal driver;
@@ -34,7 +33,7 @@ contract NodeDriverAuth is Initializable, Ownable {
 
     function incBalance(address acc, uint256 diff) external onlySFC {
         require(acc == address(sfc), "recipient is not the SFC contract");
-        driver.setBalance(acc, address(acc).balance.add(diff));
+        driver.setBalance(acc, address(acc).balance + (diff));
     }
 
     function updateNetworkRules(bytes calldata diff) external onlyOwner {
@@ -81,7 +80,7 @@ contract NodeDriverAuth is Initializable, Ownable {
 contract NodeDriver is Initializable {
     SFC internal sfc;
     NodeDriver internal backend;
-    EVMWriter internal evmWriter;
+    IEVMWriter internal evmWriter;
 
     event UpdatedBackend(address indexed backend);
 
@@ -105,7 +104,7 @@ contract NodeDriver is Initializable {
     function initialize(address _backend, address _evmWriterAddress) external initializer {
         backend = NodeDriver(_backend);
         emit UpdatedBackend(_backend);
-        evmWriter = EVMWriter(_evmWriterAddress);
+        evmWriter = IEVMWriter(_evmWriterAddress);
     }
 
     function setBalance(address acc, uint256 value) external onlyBackend {
@@ -172,7 +171,7 @@ contract NodeDriver is Initializable {
     }
 }
 
-interface EVMWriter {
+interface IEVMWriter {
     function setBalance(address acc, uint256 value) external;
 
     function copyCode(address acc, address from) external;

--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -89,7 +89,7 @@ contract SFC is Initializable, Ownable, StakersConstants, Version {
 
     mapping(uint256 => uint256) public slashingRefundRatio; // validator ID -> (slashing refund ratio)
 
-    function isNode(address addr) internal view returns (bool) {
+    function isNode(address addr) internal virtual view returns (bool) {
         return addr == address(node);
     }
 
@@ -649,7 +649,7 @@ contract SFC is Initializable, Ownable, StakersConstants, Version {
         snapshot.validatorIDs = nextValidatorIDs;
     }
 
-    function _now() internal view returns (uint256) {
+    function _now() internal view virtual returns (uint256) {
         return block.timestamp;
     }
 

--- a/contracts/sfc/StakerConstants.sol
+++ b/contracts/sfc/StakerConstants.sol
@@ -14,7 +14,7 @@ contract StakersConstants {
     /**
      * @dev Minimum amount of stake for a validator, i.e., 3175000 FTM
      */
-    function minSelfStake() public pure returns (uint256) {
+    function minSelfStake() public pure virtual returns (uint256) {
         // 3175000 FTM
         return 3175000 * 1e18;
     }

--- a/contracts/sfc/StakerConstants.sol
+++ b/contracts/sfc/StakerConstants.sol
@@ -1,10 +1,9 @@
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.1;
 
-import "@openzeppelin/contracts/math/SafeMath.sol";
 import "../common/Decimal.sol";
 
 contract StakersConstants {
-    using SafeMath for uint256;
 
     uint256 internal constant OK_STATUS = 0;
     uint256 internal constant WITHDRAWN_BIT = 1;

--- a/contracts/test/StubEvmWriter.sol
+++ b/contracts/test/StubEvmWriter.sol
@@ -1,13 +1,14 @@
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.1;
 
 import "../sfc/NodeDriver.sol";
 
-contract StubEvmWriter is EVMWriter {
-    function setBalance(address acc, uint256 value) external {}
+contract StubEvmWriter is IEVMWriter {
+    function setBalance(address acc, uint256 value) external override {}
 
-    function copyCode(address acc, address from) external {}
+    function copyCode(address acc, address from) external override {}
 
-    function swapCode(address acc, address with) external {}
+    function swapCode(address acc, address with) external override {}
 
-    function setStorage(address acc, bytes32 key, bytes32 value) external {}
+    function setStorage(address acc, bytes32 key, bytes32 value) external override {}
 }

--- a/contracts/test/UnitTestSFC.sol
+++ b/contracts/test/UnitTestSFC.sol
@@ -1,14 +1,16 @@
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.1;
 
 import "../sfc/SFC.sol";
 
 contract UnitTestSFC is SFC {
-    function minSelfStake() public pure returns (uint256) {
-        // 0.3175000 FTM
-        return 0.3175000 * 1e18;
-    }
-
     uint256 public time;
+    bool public allowedNonNodeCalls;
+
+//    function minSelfStake() public pure returns (uint256) {
+//        // 0.3175000 FTM
+//        return 0.3175000 * 1e18;
+//    }
 
     function rebaseTime() external {
         time = block.timestamp;
@@ -18,7 +20,7 @@ contract UnitTestSFC is SFC {
         time += diff;
     }
 
-    function _now() internal view returns (uint256) {
+    function _now() internal view override returns (uint256) {
         return time;
     }
 
@@ -33,8 +35,6 @@ contract UnitTestSFC is SFC {
     function highestLockupEpoch(address delegator, uint256 validatorID) external view returns (uint256) {
         return _highestLockupEpoch(delegator, validatorID);
     }
-
-    bool public allowedNonNodeCalls;
 
     function enableNonNodeCalls() external {
         allowedNonNodeCalls = true;

--- a/contracts/test/UnitTestSFC.sol
+++ b/contracts/test/UnitTestSFC.sol
@@ -7,10 +7,10 @@ contract UnitTestSFC is SFC {
     uint256 public time;
     bool public allowedNonNodeCalls;
 
-//    function minSelfStake() public pure returns (uint256) {
-//        // 0.3175000 FTM
-//        return 0.3175000 * 1e18;
-//    }
+    function minSelfStake() public pure override returns (uint256) {
+        // 0.3175000 FTM
+        return 0.3175000 * 1e18;
+    }
 
     function rebaseTime() external {
         time = block.timestamp;

--- a/contracts/test/UnitTestSFC.sol
+++ b/contracts/test/UnitTestSFC.sol
@@ -44,7 +44,7 @@ contract UnitTestSFC is SFC {
         allowedNonNodeCalls = false;
     }
 
-    function isNode(address addr) internal view returns (bool) {
+    function isNode(address addr) internal view override returns (bool) {
         if (allowedNonNodeCalls) {
             return true;
         }

--- a/contracts/version/Version.sol
+++ b/contracts/version/Version.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.1;
 
 /**
  * @dev Version contract gives the versioning information of the implementation contract

--- a/test/SFC.js
+++ b/test/SFC.js
@@ -289,7 +289,7 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator]) => {
 
             it('Should return Now()', async () => {
                 const now = Math.trunc((Date.now()) / 1000);
-                expect((await this.sfc.getBlockTime()).toNumber()).to.be.within(now - 10, now + 10);
+                expect((await this.sfc.getBlockTime()).toNumber()).to.be.within(now - 15, now + 15);
             });
         });
 
@@ -553,7 +553,7 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
 
         it('Should returns Validator\'s Created Time', async () => {
             const now = Math.trunc((Date.now()) / 1000);
-            expect(validator.createdTime.toNumber()).to.be.within(now - 2, now + 2);
+            expect(validator.createdTime.toNumber()).to.be.within(now - 15, now + 15);
         });
 
         it('Should returns Validator\'s Auth (address)', async () => {

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -25,7 +25,7 @@
 // const mnemonic = fs.readFileSync(".secret").toString().trim();
 
 module.exports = {
-  /**
+    /**
    * Networks define how you connect to your ethereum client and let you set the
    * defaults web3 uses to send transactions. If you don't specify one truffle
    * will spin up a development blockchain for you on port 9545 when you
@@ -35,7 +35,7 @@ module.exports = {
    * $ truffle test --network <network-name>
    */
 
-  networks: {
+    networks: {
     // Useful for testing. The `development` name is special - truffle uses it by default
     // if it's defined here and no other network is specified at the command line.
     // You should run a client (like ganache-cli, geth or parity) in a separate terminal
@@ -48,53 +48,53 @@ module.exports = {
     //  network_id: "*",       // Any network (default: none)
     // },
 
-    // Another network with more advanced options...
-    // advanced: {
-      // port: 8777,             // Custom port
-      // network_id: 1342,       // Custom network
-      // gas: 8500000,           // Gas sent with each transaction (default: ~6700000)
-      // gasPrice: 20000000000,  // 20 gwei (in wei) (default: 100 gwei)
-      // from: <address>,        // Account to send txs from (default: accounts[0])
-      // websockets: true        // Enable EventEmitter interface for web3 (default: false)
-    // },
+        // Another network with more advanced options...
+        // advanced: {
+        // port: 8777,             // Custom port
+        // network_id: 1342,       // Custom network
+        // gas: 8500000,           // Gas sent with each transaction (default: ~6700000)
+        // gasPrice: 20000000000,  // 20 gwei (in wei) (default: 100 gwei)
+        // from: <address>,        // Account to send txs from (default: accounts[0])
+        // websockets: true        // Enable EventEmitter interface for web3 (default: false)
+        // },
 
-    // Useful for deploying to a public network.
-    // NB: It's important to wrap the provider as a function.
-    // ropsten: {
-      // provider: () => new HDWalletProvider(mnemonic, `https://ropsten.infura.io/v3/YOUR-PROJECT-ID`),
-      // network_id: 3,       // Ropsten's id
-      // gas: 5500000,        // Ropsten has a lower block limit than mainnet
-      // confirmations: 2,    // # of confs to wait between deployments. (default: 0)
-      // timeoutBlocks: 200,  // # of blocks before a deployment times out  (minimum/default: 50)
-      // skipDryRun: true     // Skip dry run before migrations? (default: false for public nets )
-    // },
+        // Useful for deploying to a public network.
+        // NB: It's important to wrap the provider as a function.
+        // ropsten: {
+        // provider: () => new HDWalletProvider(mnemonic, `https://ropsten.infura.io/v3/YOUR-PROJECT-ID`),
+        // network_id: 3,       // Ropsten's id
+        // gas: 5500000,        // Ropsten has a lower block limit than mainnet
+        // confirmations: 2,    // # of confs to wait between deployments. (default: 0)
+        // timeoutBlocks: 200,  // # of blocks before a deployment times out  (minimum/default: 50)
+        // skipDryRun: true     // Skip dry run before migrations? (default: false for public nets )
+        // },
 
     // Useful for private networks
     // private: {
-      // provider: () => new HDWalletProvider(mnemonic, `https://network.io`),
-      // network_id: 2111,   // This network is yours, in the cloud.
-      // production: true    // Treats this network as if it was a public net. (default: false)
+        // provider: () => new HDWalletProvider(mnemonic, `https://network.io`),
+        // network_id: 2111,   // This network is yours, in the cloud.
+        // production: true    // Treats this network as if it was a public net. (default: false)
     // }
-  },
+    },
 
-  // Set default mocha options here, use special reporters etc.
-  mocha: {
+    // Set default mocha options here, use special reporters etc.
+    mocha: {
     // timeout: 100000
-  },
+    },
 
-  // Configure your compilers
-  compilers: {
-    solc: {
-      // version: "0.5.1",    // Fetch exact version from solc-bin (default: truffle's version)
-      // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
-      settings: {          // See the solidity docs for advice about optimization and evmVersion
-        optimizer: {
-          enabled: true,
-          runs: 10000
+    // Configure your compilers
+    compilers: {
+        solc: {
+            version: '0.8.1', // Fetch exact version from solc-bin (default: truffle's version)
+            // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
+            settings: { // See the solidity docs for advice about optimization and evmVersion
+                optimizer: {
+                    enabled: true,
+                    runs: 10000,
+                },
+                //  evmVersion: "byzantium"
+            },
         },
-      //  evmVersion: "byzantium"
-      }
-    }
-  },
-  plugins: ["solidity-coverage"]
-}
+    },
+    plugins: ['solidity-coverage'],
+};


### PR DESCRIPTION
I removed safemath because it wasn't used appropriately.  Prevention is better than cure, that's why this PR
**Reason**: 
There are parts where safemath was used and parts where not. Which can lead to undefined behavior, especially with multiplications and divisions, (there were many who were not using safemath methods, like [here for example](https://github.com/Fantom-foundation/opera-sfc/blob/develop/contracts/sfc/SFC.sol#L608-L613)). 
**Solution**:
I've updated the code to solidity version 0.8.1, which natively includes Safemath, so if we ever encounter an overflow (for example), it'll revert instead of having an undefined behavior, and we will have to do it sooner or later anyway!

- [x] Removing Safemath
- [x] Remove the use of safemath library and changes all safemath calls to native calls
- [x] Update to 0.8.1 and make changes for compiler
- [x] Compilation (fix virtual / override functions)
- [ ] tests (to be fixed)

