### PR TITLE
Backward compatibility with 2.0.2

### DIFF
--- a/contracts/sfc/LegacySfcWrapper.sol
+++ b/contracts/sfc/LegacySfcWrapper.sol
@@ -162,7 +162,7 @@ contract LegacySfcWrapper is SFC {
         revert("use SFCv3 withdraw() function");
     }
 
-    function prepareToWithdrawDelegation(uint256 toStakerID) external {
+    function prepareToWithdrawDelegation(uint256 /*toStakerID*/) external {
         if (false) {
             address(0).transfer(0);
         }
@@ -173,7 +173,7 @@ contract LegacySfcWrapper is SFC {
         undelegate(toStakerID, wrID, amount);
     }
 
-    function withdrawDelegation(uint256 toStakerID) external {
+    function withdrawDelegation(uint256 /*toStakerID*/) external {
         if (false) {
             address(0).transfer(0);
         }

--- a/contracts/sfc/LegacySfcWrapper.sol
+++ b/contracts/sfc/LegacySfcWrapper.sol
@@ -1,0 +1,198 @@
+pragma solidity ^0.5.0;
+
+import "./SFC.sol";
+
+// LegacySfcWrapper adds the legacy SFCv2 functions for backward compatibility
+contract LegacySfcWrapper is SFC {
+    function minStake() public pure returns (uint256) {
+        return minSelfStake();
+    }
+
+    function minStakeIncrease() public pure returns (uint256) {
+        return 0;
+    }
+
+    function minStakeDecrease() public pure returns (uint256) {
+        return 0;
+    }
+
+    function minDelegation() public pure returns (uint256) {
+        return 0;
+    }
+
+    function minDelegationIncrease() public pure returns (uint256) {
+        return 0;
+    }
+
+    function minDelegationDecrease() public pure returns (uint256) {
+        return 0;
+    }
+
+    function stakeLockPeriodTime() public pure returns (uint256) {
+        return withdrawalPeriodEpochs();
+    }
+
+    function stakeLockPeriodEpochs() public pure returns (uint256) {
+        return withdrawalPeriodEpochs();
+    }
+
+    function delegationLockPeriodTime() public pure returns (uint256) {
+        return withdrawalPeriodTime();
+    }
+
+    function delegationLockPeriodEpochs() public pure returns (uint256) {
+        return withdrawalPeriodEpochs();
+    }
+
+    function delegations(address _from, uint256 _toStakerID) external view returns (uint256 createdEpoch, uint256 createdTime,
+        uint256 deactivatedEpoch, uint256 deactivatedTime, uint256 amount, uint256 paidUntilEpoch, uint256 toStakerID) {
+        uint256 stake = getStake[_from][_toStakerID];
+        if (stake == 0) {
+            return (0, 0, 0, 0, 0, 0, 0);
+        }
+        return (1, 1, 0, 0, stake, 1, _toStakerID);
+    }
+
+    function stakers(uint256 _stakerID) external view returns (uint256 status, uint256 createdEpoch, uint256 createdTime,
+        uint256 deactivatedEpoch, uint256 deactivatedTime, uint256 stakeAmount, uint256 paidUntilEpoch, uint256 delegatedMe, address dagAddress, address sfcAddress) {
+        Validator memory v = getValidator[_stakerID];
+        if (v.status == OFFLINE_BIT) {
+            v.status = 1 << 8;
+        } else if (v.status == DOUBLESIGN_BIT) {
+            v.status = 1;
+        } else if (v.status == WITHDRAWN_BIT) {
+            v.status = 0;
+        }
+        uint256 selfStake = _getSelfStake(_stakerID);
+        return (v.status, v.createdEpoch, v.createdTime, v.deactivatedEpoch, v.deactivatedTime, selfStake, 1, v.receivedStake.sub(selfStake), v.auth, v.auth);
+    }
+
+    function getStakerID(address _addr) external view returns (uint256) {
+        return getValidatorID[_addr];
+    }
+
+    function stakeTotalAmount() public view returns (uint256) {
+        // Note: estimate the total self stake, as it cannot be calculated cheaply in SFC v3
+        return (totalStake * 24) / 100;
+    }
+
+    function delegationsTotalAmount() external view returns (uint256) {
+        return totalStake - stakeTotalAmount();
+    }
+
+    function isDelegationLockedUp(address delegator, uint256 toStakerID) view public returns (bool) {
+        return isLockedUp(delegator, toStakerID);
+    }
+
+    function isStakeLockedUp(uint256 stakerID) view public returns (bool) {
+        return isLockedUp(getValidator[stakerID].auth, stakerID);
+    }
+
+    function stakersLastID() view public returns (uint256) {
+        return lastValidatorID;
+    }
+
+    function stakersNum() view public returns (uint256) {
+        return lastValidatorID;
+    }
+
+    function delegationsNum() pure public returns (uint256) {
+        return 0;
+    }
+
+    function lockedDelegations(address delegator, uint256 toStakerID) public view returns (uint256 fromEpoch, uint256 endTime, uint256 duration) {
+        LockedDelegation memory l = getLockupInfo[delegator][toStakerID];
+        return (l.fromEpoch, l.endTime, l.duration);
+    }
+
+    function lockedStakes(uint256 stakerID) external view returns (uint256 fromEpoch, uint256 endTime, uint256 duration) {
+        return lockedDelegations(getValidator[stakerID].auth, stakerID);
+    }
+
+    function createDelegation(uint256 toValidatorID) external payable {
+        _delegate(msg.sender, toValidatorID, msg.value);
+    }
+
+    function calcDelegationRewards(address delegator, uint256 toStakerID, uint256 /*_fromEpoch*/, uint256 /*maxEpochs*/) public view returns (uint256, uint256, uint256) {
+        return (pendingRewards(delegator, toStakerID), currentSealedEpoch, currentSealedEpoch);
+    }
+
+    function calcValidatorRewards(uint256 stakerID, uint256 /*_fromEpoch*/, uint256 /*maxEpochs*/) public view returns (uint256, uint256, uint256) {
+        return (pendingRewards(getValidator[stakerID].auth, stakerID), currentSealedEpoch, currentSealedEpoch);
+    }
+
+
+    function claimDelegationRewards(uint256 /*maxEpochs*/, uint256 toStakerID) external {
+        claimRewards(toStakerID);
+    }
+
+
+    function claimDelegationCompoundRewards(uint256 /*maxEpochs*/, uint256 toStakerID) external {
+        restakeRewards(toStakerID);
+    }
+
+
+    function claimValidatorRewards(uint256 /*maxEpochs*/) external {
+        uint256 validatorID = getValidatorID[msg.sender];
+        claimRewards(validatorID);
+    }
+
+
+    function claimValidatorCompoundRewards(uint256 /*maxEpochs*/) external {
+        uint256 validatorID = getValidatorID[msg.sender];
+        restakeRewards(validatorID);
+    }
+
+    function prepareToWithdrawStake() external {
+        if (false) {
+            address(0).transfer(0);
+        }
+        revert("use SFCv3 undelegate() function");
+    }
+
+    function prepareToWithdrawStakePartial(uint256 wrID, uint256 amount) external {
+        uint256 validatorID = getValidatorID[msg.sender];
+        undelegate(validatorID, wrID, amount);
+    }
+
+    function withdrawStake() external {
+        if (false) {
+            address(0).transfer(0);
+        }
+        revert("use SFCv3 withdraw() function");
+    }
+
+    function prepareToWithdrawDelegation(uint256 toStakerID) external {
+        if (false) {
+            address(0).transfer(0);
+        }
+        revert("use SFCv3 undelegate() function");
+    }
+
+    function prepareToWithdrawDelegationPartial(uint256 wrID, uint256 toStakerID, uint256 amount) external {
+        undelegate(toStakerID, wrID, amount);
+    }
+
+    function withdrawDelegation(uint256 toStakerID) external {
+        if (false) {
+            address(0).transfer(0);
+        }
+        revert("use SFCv3 withdraw() function");
+    }
+
+    function partialWithdrawByRequest(uint256) external {
+        if (false) {
+            address(0).transfer(0);
+        }
+        revert("use SFCv3 withdraw() function");
+    }
+
+    function lockUpStake(uint256 lockDuration) external {
+        uint256 validatorID = getValidatorID[msg.sender];
+        lockStake(validatorID, lockDuration, _getSelfStake(validatorID));
+    }
+
+    function lockUpDelegation(uint256 lockDuration, uint256 toStakerID) external {
+        lockStake(toStakerID, lockDuration, getStake[msg.sender][toStakerID]);
+    }
+}

--- a/contracts/sfc/NodeDriver.sol
+++ b/contracts/sfc/NodeDriver.sol
@@ -37,6 +37,11 @@ contract NodeDriverAuth is Initializable, Ownable {
         driver.setBalance(acc, address(acc).balance.add(diff));
     }
 
+    function copyCode(address acc, address from) external onlyOwner {
+        require(acc == address(sfc) || acc == address(this), "not SFC or self address");
+        driver.copyCode(acc, from);
+    }
+
     function updateNetworkRules(bytes calldata diff) external onlyOwner {
         driver.updateNetworkRules(diff);
     }

--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -729,7 +729,7 @@ contract SFC is Initializable, Ownable, StakersConstants, Version {
         return getLockupInfo[delegator][toValidatorID].lockedStake;
     }
 
-    function lockStake(uint256 toValidatorID, uint256 lockupDuration, uint256 amount) external {
+    function lockStake(uint256 toValidatorID, uint256 lockupDuration, uint256 amount) public {
         address delegator = msg.sender;
 
         require(amount > 0, "zero amount");

--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -191,6 +191,7 @@ contract SFC is Initializable, Ownable, StakersConstants, Version {
 
     function createValidator(bytes calldata pubkey) external payable {
         require(msg.value >= minSelfStake(), "insufficient self-stake");
+        require(pubkey.length > 0, "empty pubkey");
         _createValidator(msg.sender, pubkey);
         _delegate(msg.sender, lastValidatorID, msg.value);
     }

--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -99,7 +99,7 @@ contract SFC is Initializable, Ownable, StakersConstants, Version {
         _;
     }
 
-    event CreatedValidator(uint256 indexed validatorID, address indexed auth, bytes pubkey, uint256 createdEpoch, uint256 createdTime);
+    event CreatedValidator(uint256 indexed validatorID, address indexed auth, uint256 createdEpoch, uint256 createdTime);
     event DeactivatedValidator(uint256 indexed validatorID, uint256 deactivatedEpoch, uint256 deactivatedTime);
     event ChangedValidatorStatus(uint256 indexed validatorID, uint256 status);
     event Delegated(address indexed delegator, uint256 indexed toValidatorID, uint256 amount);
@@ -211,7 +211,7 @@ contract SFC is Initializable, Ownable, StakersConstants, Version {
         getValidator[validatorID].auth = auth;
         getValidatorPubkey[validatorID] = pubkey;
 
-        emit CreatedValidator(validatorID, auth, pubkey, createdEpoch, createdTime);
+        emit CreatedValidator(validatorID, auth, createdEpoch, createdTime);
         if (deactivatedEpoch != 0) {
             emit DeactivatedValidator(validatorID, deactivatedEpoch, deactivatedTime);
         }

--- a/contracts/sfc/StakerConstants.sol
+++ b/contracts/sfc/StakerConstants.sol
@@ -67,29 +67,14 @@ contract StakersConstants {
     }
 
     /**
-     * @dev the period of time that stake is locked
-     */
-    function stakeLockPeriodTime() public pure returns (uint256) {
-        // 7 days
-        return 60 * 60 * 24 * 7;
-    }
-
-    /**
      * @dev the number of epochs that stake is locked
      */
-    function unstakePeriodEpochs() public pure returns (uint256) {
+    function withdrawalPeriodEpochs() public pure returns (uint256) {
         return 3;
     }
 
-    function unstakePeriodTime() public pure returns (uint256) {
+    function withdrawalPeriodTime() public pure returns (uint256) {
         // 7 days
         return 60 * 60 * 24 * 7;
-    }
-
-    /**
-     * @dev number of epochs to lock a delegation
-     */
-    function delegationLockPeriodEpochs() public pure returns (uint256) {
-        return 3;
     }
 }

--- a/contracts/version/Version.sol
+++ b/contracts/version/Version.sol
@@ -8,7 +8,7 @@ contract Version {
      * @dev Returns the address of the current owner.
      */
     function version() public pure returns (bytes3) {
-        // version 2.0.2
-        return "202";
+        // version 3.0.0
+        return "300";
     }
 }

--- a/test/SFC.js
+++ b/test/SFC.js
@@ -220,7 +220,7 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator]) => {
             });
 
             it('Returns the version of the current implementation', async () => {
-                expect((await this.sfc.version()).toString()).to.equals('0x323032');
+                expect((await this.sfc.version()).toString()).to.equals('0x333030');
             });
 
             it('Should create a Validator and return the ID', async () => {

--- a/test/SFC.js
+++ b/test/SFC.js
@@ -212,23 +212,11 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator]) => {
             });
 
             it('Returns the period of time that stake is locked', async () => {
-                expect((await this.sfc.stakeLockPeriodTime()).toString()).to.equals('604800');
+                expect((await this.sfc.withdrawalPeriodTime()).toString()).to.equals('604800');
             });
 
             it('Returns the number of epochs that stake is locked', async () => {
-                expect((await this.sfc.unstakePeriodEpochs()).toString()).to.equals('3');
-            });
-
-            it('Returns the period of time that stake is locked', async () => {
-                expect((await this.sfc.stakeLockPeriodTime()).toString()).to.equals('604800');
-            });
-
-            it('Returns the number of Time that stake is locked', async () => {
-                expect((await this.sfc.unstakePeriodTime()).toString()).to.equals('604800');
-            });
-
-            it('Returns the number of epochs to lock a delegation', async () => {
-                expect((await this.sfc.delegationLockPeriodEpochs()).toString()).to.equals('3');
+                expect((await this.sfc.withdrawalPeriodEpochs()).toString()).to.equals('3');
             });
 
             it('Returns the version of the current implementation', async () => {
@@ -580,7 +568,7 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
             validator = await this.sfc.getValidator(1);
         });
 
-        it('Returns claimedRewardUntilEpoch', async () => {
+        it('Returns stashedRewardUntilEpoch', async () => {
             expect(await this.sfc.currentSealedEpoch.call()).to.be.bignumber.equal(new BN('12'));
             expect(await this.sfc.currentEpoch.call()).to.be.bignumber.equal(new BN('13'));
             await this.sfc.sealEpoch([100, 101, 102], [100, 101, 102], [100, 101, 102], [100, 101, 102]);
@@ -782,9 +770,9 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, firstDe
             await this.sfc.updateBaseRewardPerSecond(new BN('1'));
             await sealEpoch(this.sfc, (new BN(60 * 60 * 24)).toString());
             await sealEpoch(this.sfc, (new BN(60 * 60 * 24)).toString());
-            expect(await this.sfc.claimedRewardUntilEpoch(firstDelegator, 1)).to.bignumber.equal(new BN(0));
+            expect(await this.sfc.stashedRewardUntilEpoch(firstDelegator, 1)).to.bignumber.equal(new BN(0));
             await this.sfc.claimRewards(1, { from: firstDelegator });
-            expect(await this.sfc.claimedRewardUntilEpoch(firstDelegator, 1)).to.bignumber.equal(await this.sfc.currentSealedEpoch());
+            expect(await this.sfc.stashedRewardUntilEpoch(firstDelegator, 1)).to.bignumber.equal(await this.sfc.currentSealedEpoch());
         });
 
         it('Check pending Rewards of delegators', async () => {


### PR DESCRIPTION
- add SFCv2 interface wrapper
- add restakeRewards method for backward compatibility with SFCv2 claim*CompoundRewards methods
- refactor early unlocking penalty tracking to allow future modifications
- SFC contract is upgradeable with copyCode method