### PR TITLE
Fix stake lock check to include non-zero locked amount.

### DIFF
--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -725,7 +725,7 @@ contract SFC is Initializable, Ownable, StakersConstants, Version {
     }
 
     function isLockedUp(address delegator, uint256 toValidatorID) view public returns (bool) {
-        return getLockupInfo[delegator][toValidatorID].endTime != 0 && _now() <= getLockupInfo[delegator][toValidatorID].endTime;
+        return getLockupInfo[delegator][toValidatorID].endTime != 0 && getLockupInfo[delegator][toValidatorID].lockedStake != 0 && _now() <= getLockupInfo[delegator][toValidatorID].endTime;
     }
 
     function _isLockedUpAtEpoch(address delegator, uint256 toValidatorID, uint256 epoch) internal view returns (bool) {


### PR DESCRIPTION
If a staker calls unlockStake() for the full locked stake amount before the lock expires naturally, the amount staked is reduced to zero, but the original lock end time is still in place. This prevents a new lock to be placed since the isLockedUp() check still returns TRUE. The purpose of the PR is to allow such stakers to place a new lock before the previous lock timer expires naturally.