### PR TITLE
Refund slashed legacy delegations

### DIFF
--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -124,6 +124,7 @@ contract SFC is Initializable, Ownable, StakersConstants, Version {
     event UpdatedBaseRewardPerSec(uint256 value);
     event UpdatedOfflinePenaltyThreshold(uint256 blocksNum, uint256 period);
     event UpdatedSlashingRefundRatio(uint256 indexed validatorID, uint256 refundRatio);
+    event RefundedSlashedLegacyDelegation(address indexed delegator, uint256 indexed validatorID, uint256 amount);
 
     /*
     Getters
@@ -827,5 +828,13 @@ contract SFC is Initializable, Ownable, StakersConstants, Version {
 
         emit UnlockedStake(delegator, toValidatorID, amount, penalty);
         return penalty;
+    }
+
+    function refundSlashedLegacyDelegation(address payable delegator, uint256 toValidatorID, uint256 amount) external onlyOwner {
+        require(isSlashed(toValidatorID), "validator isn't slashed");
+        require(amount <= 1457100266114788805830000, "amount is too high");
+        _mintNativeToken(amount);
+        delegator.transfer(amount);
+        emit RefundedSlashedLegacyDelegation(delegator, toValidatorID, amount);
     }
 }

--- a/contracts/version/Version.sol
+++ b/contracts/version/Version.sol
@@ -8,7 +8,7 @@ contract Version {
      * @dev Returns the address of the current owner.
      */
     function version() public pure returns (bytes3) {
-        // version 3.0.1
-        return "301";
+        // version 3.0.2
+        return "302";
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opera-sfc",
-  "version": "1.0.0-RC",
+  "version": "3.0.2-rc1",
   "description": "Special Fee Contract",
   "scripts": {
     "lint:js": "eslint \"test/*.js\"",

--- a/test/SFC.js
+++ b/test/SFC.js
@@ -1239,6 +1239,15 @@ contract('SFC', async ([firstValidator, secondValidator, thirdValidator, testVal
             await expect(this.sfc.sealEpoch(offlineTimes, offlineBlocks, uptimes, originatedTxsFees)).to.be.fulfilled;
             await expect(this.sfc.sealEpochValidators(allValidators)).to.be.fulfilled;
         });
+
+        it('Should refund legacy delegation', async () => {
+            await expectRevert(this.sfc.refundSlashedLegacyDelegation(account2, 1, amount18('1.5'), { from: secondValidator }), 'Ownable: caller is not the owner');
+            await expectRevert(this.sfc.refundSlashedLegacyDelegation(account2, 1, amount18('1.5'), { from: firstValidator }), "validator isn't slashed");
+            await this.sfc.deactivateValidator(1, 1 << 7);
+            const delegatorBalance = new BN(await web3.eth.getBalance(account2));
+            await this.sfc.refundSlashedLegacyDelegation(account2, 1, amount18('1.5'), { from: firstValidator });
+            expect(delegatorBalance.add(amount18('1.5'))).to.be.bignumber.equal(await web3.eth.getBalance(account2));
+        });
     });
 
     describe('Stake lockup', () => {


### PR DESCRIPTION
- allow to refund slashed legacy delegations by an owner. The method is stateless