### PR TITLE
Change the re-lock behavior to allow shorter extensions.

### DIFF
--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -746,7 +746,7 @@ contract SFC is Initializable, Ownable, StakersConstants, Version {
         return getLockupInfo[delegator][toValidatorID].fromEpoch <= epoch && epochEndTime(epoch) <= getLockupInfo[delegator][toValidatorID].endTime;
     }
 
-    function _checkAllowedToWithdraw(address delegator, uint256 toValidatorID) internal view returns(bool) {
+    function _checkAllowedToWithdraw(address delegator, uint256 toValidatorID) internal view returns (bool) {
         if (stakeTokenizerAddress == address(0)) {
             return true;
         }
@@ -775,7 +775,16 @@ contract SFC is Initializable, Ownable, StakersConstants, Version {
 
         // check lockup duration after _stashRewards, which has erased previous lockup if it has unlocked already
         LockedDelegation storage ld = getLockupInfo[delegator][toValidatorID];
-        require(lockupDuration >= ld.duration, "lockup duration cannot decrease");
+        require(endTime >= ld.endTime, "lockup cannot end earlier");
+
+        // if re-lock, calculate combined lock duration adding passed part of the existing one to the new one
+        // make sure not to exceed the max duration limit
+        if (ld.endTime > 0) {
+            lockupDuration += _now() - (ld.endTime - ld.duration);
+            if (lockupDuration > maxLockupDuration()) {
+                lockupDuration = maxLockupDuration();
+            }
+        }
 
         ld.lockedStake = ld.lockedStake.add(amount);
         ld.fromEpoch = currentEpoch();


### PR DESCRIPTION
The new lock end date after the re-lock attempt must exceed previous end date, so the lock length can not be shortened. The new duration can be shorter than the previous one. But since the rewards are based on duration length, we want to re-calculate duration before storing it so it reflects the extended lock time from now on. The newly stored duration adds passed part of the previous lock to the new duration reflecting the total length of the lock. The upper limit of the lock duration is still obeyed.