### PR TITLE
Removed selfStakeAfterwards and DelegatedStakeLimit checks for inactive validators

### DIFF
--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -311,8 +311,10 @@ contract SFC is Initializable, Ownable, StakersConstants, Version {
 
         uint256 selfStakeAfterwards = getSelfStake(toValidatorID);
         if (selfStakeAfterwards != 0) {
-            require(selfStakeAfterwards >= minSelfStake(), "insufficient self-stake");
-            require(_checkDelegatedStakeLimit(toValidatorID), "validator's delegations limit is exceeded");
+            if (getValidator[toValidatorID].status == OK_STATUS) {
+                require(selfStakeAfterwards >= minSelfStake(), "insufficient self-stake");
+                require(_checkDelegatedStakeLimit(toValidatorID), "validator's delegations limit is exceeded");
+            }
         } else {
             _setValidatorDeactivated(toValidatorID, WITHDRAWN_BIT);
         }
@@ -746,7 +748,7 @@ contract SFC is Initializable, Ownable, StakersConstants, Version {
         return getLockupInfo[delegator][toValidatorID].fromEpoch <= epoch && epochEndTime(epoch) <= getLockupInfo[delegator][toValidatorID].endTime;
     }
 
-    function _checkAllowedToWithdraw(address delegator, uint256 toValidatorID) internal view returns(bool) {
+    function _checkAllowedToWithdraw(address delegator, uint256 toValidatorID) internal view returns (bool) {
         if (stakeTokenizerAddress == address(0)) {
             return true;
         }


### PR DESCRIPTION
Reason: current behaviour blocks possibility to withdraw funds for validators, that already called claimRewards and was blocked (for example, for being offline) afterwards. Precisely, function unlockStake can not be called for such validator.

Calling unlockStake triggers _rawUndelegate(.., penalty), if stake of validator is less than minStake + penalty, this will not work. Also it is not possible to stake more funds to validator to work around this issue as validator is already deactivated.