### PR TITLE
Feature/gas subsidies

### DIFF
--- a/contracts/sfc/SFCState.sol
+++ b/contracts/sfc/SFCState.sol
@@ -106,4 +106,13 @@ contract SFCState is Initializable, Ownable {
     ConstantsManager internal c;
 
     address public voteBookAddress;
+
+    struct Sponsor {
+        uint256 gasLimit;
+        uint256 index;
+    }
+    //nominee -> sponsors list
+    mapping(address => address[]) public sponsors;
+    //nominee -> sponsor -> sponsor info
+    mapping(address => mapping(address => Sponsor)) public getSponsorInfo;
 }

--- a/contracts/test/UnitTestSFC.sol
+++ b/contracts/test/UnitTestSFC.sol
@@ -248,6 +248,16 @@ interface SFCUnitTestI {
     function updateVoteBookAddress(address v) external;
 
     function voteBookAddress(address v) external view returns (address);
+
+    function approveSponsorship(address _nominee, uint256 _gasLimit) external;
+
+    function revokeSponsorship(address _nominee) external;
+
+    function getSponsor(address _nominee, uint256 _gasAmount) external view returns(address);
+
+    function getSponsorInfo(address _nominee, address _sponsor) external view returns(uint256 _gasLimit, uint256 _index);
+
+    function getSponsors(address _nominee) external view returns(address[] memory);
 }
 
 


### PR DESCRIPTION
This feature allows SFC to implement gas subsidies functionality on go-opera. 'Sponsor' account pays the gas fees when  user interacts with a 'Nominee' contract address.

It contains methods for:

- adding a 'Sponsor' address for a given 'Nominee' address with a specified gas amount
- removing a 'Sponsor' address for a given 'Nominee' address
- getter that returns first 'Sponsor' address with enough amount of gas from the list of sponsors for the specified 'Nominee' address