### PR TITLE
Feature/gas monetization

### DIFF
--- a/contracts/sfc/SFCLib.sol
+++ b/contracts/sfc/SFCLib.sol
@@ -20,6 +20,7 @@ contract SFCLib is SFCBase {
     event UpdatedSlashingRefundRatio(uint256 indexed validatorID, uint256 refundRatio);
     event RefundedSlashedLegacyDelegation(address indexed delegator, uint256 indexed validatorID, uint256 amount);
 
+    event NewTargetRecipientRoute(address indexed target, address indexed recipient);
     /*
     Getters
     */
@@ -519,5 +520,11 @@ contract SFCLib is SFCBase {
         require(refundRatio <= Decimal.unit(), "must be less than or equal to 1.0");
         slashingRefundRatio[validatorID] = refundRatio;
         emit UpdatedSlashingRefundRatio(validatorID, refundRatio);
+    }
+
+    function setTargetRecipientRoute(address target, address recipient) onlyOwner external {
+        require(target != address(0), "wrong target address");
+        getRecipient[target] = recipient;
+        emit NewTargetRecipientRoute(target, recipient);
     }
 }

--- a/contracts/sfc/SFCState.sol
+++ b/contracts/sfc/SFCState.sol
@@ -106,4 +106,6 @@ contract SFCState is Initializable, Ownable {
     ConstantsManager internal c;
 
     address public voteBookAddress;
+
+    mapping(address => address) public getRecipient; // target => recipient
 }

--- a/contracts/test/UnitTestSFC.sol
+++ b/contracts/test/UnitTestSFC.sol
@@ -248,6 +248,10 @@ interface SFCUnitTestI {
     function updateVoteBookAddress(address v) external;
 
     function voteBookAddress(address v) external view returns (address);
+
+    function getRecipient(address target) external view returns (address);
+
+    function setTargetRecipientRoute(address target, address recipient) external;
 }
 
 

--- a/test/SFC.js
+++ b/test/SFC.js
@@ -1813,3 +1813,29 @@ contract('SFC', async ([firstValidator, testValidator, firstDelegator, secondDel
         });
     });
 });
+
+contract('SFC', async ([account1, account2, account3]) => {
+    let nodeIRaw;
+    beforeEach(async () => {
+        this.sfc = await SFCI.at((await UnitTestSFC.new()).address);
+        nodeIRaw = await NodeDriver.new();
+        const evmWriter = await StubEvmWriter.new();
+        this.nodeI = await NodeDriverAuth.new();
+        this.sfcLib = await UnitTestSFCLib.new();
+        const initializer = await NetworkInitializer.new();
+        await initializer.initializeAll(12, 0, this.sfc.address, this.sfcLib.address, this.nodeI.address, nodeIRaw.address, evmWriter.address, account1);
+        this.consts = await ConstantsManager.at(await this.sfc.constsAddress.call());
+    });
+
+    describe('Gas monetization', () => {
+        it('Sets a recipient for a target contract', async () => {
+            await this.sfc.setTargetRecipientRoute(account2, account3, {from: account1});
+            const recipient = await this.sfc.getRecipient(account2);
+            expect(recipient).to.be.equal(account3)    
+        });
+        it('Only owner can set a recipient for a target contract', async () => {
+            await expectRevert(this.sfc.setTargetRecipientRoute(account2, account3, {from: account3}), 'Ownable: caller is not the owner');
+        });
+    });
+});
+


### PR DESCRIPTION
This feature allows SFC to implement gas monetization on go-opera. Recipient address shares gas fee percentage from transactions with the target address.

It contains methods for:

creating new target-recipient pair
viewing recipient of the target contract