### PR TITLE
Add an option to withdraw to a different recipient

### DIFF
--- a/contracts/test/UnitTestSFC.sol
+++ b/contracts/test/UnitTestSFC.sol
@@ -181,6 +181,8 @@ interface SFCUnitTestI {
 
     function withdraw(uint256 toValidatorID, uint256 wrID) external;
 
+    function withdrawTo(uint256 toValidatorID, uint256 wrID, address payable recipient) external;
+
     function deactivateValidator(uint256 validatorID, uint256 status) external;
 
     function pendingRewards(address delegator, uint256 toValidatorID) external view returns (uint256);


### PR DESCRIPTION
A stake withdraw request is finalised by calling the `withdraw()` function after the `withdrawalPeriodTime()` passed. The undelegated amount is sent to the stake owner address as part of the withdrawal process. This adds an option to withdraw the pending request amount to a different recipient instead.