### PR TITLE
Add multipenalties support

### DIFF
--- a/contracts/common/SafeMath.sol
+++ b/contracts/common/SafeMath.sol
@@ -1,0 +1,156 @@
+pragma solidity ^0.5.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     * - Subtraction cannot overflow.
+     *
+     * _Available since v2.4.0._
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     * - The divisor cannot be zero.
+     *
+     * _Available since v2.4.0._
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        // Solidity only automatically asserts when dividing by 0
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     * - The divisor cannot be zero.
+     *
+     * _Available since v2.4.0._
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}

--- a/contracts/erc20/base/ERC20.sol
+++ b/contracts/erc20/base/ERC20.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import "../../common/SafeMath.sol";
 import "./IERC20.sol";
 import "../../common/Initializable.sol";
 

--- a/contracts/sfc/ConstantsManager.sol
+++ b/contracts/sfc/ConstantsManager.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import "../common/SafeMath.sol";
 import "../ownership/Ownable.sol";
 import "../common/Decimal.sol";
 

--- a/contracts/sfc/NodeDriver.sol
+++ b/contracts/sfc/NodeDriver.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import "../common/SafeMath.sol";
 import "../common/Initializable.sol";
 import "../ownership/Ownable.sol";
 import "./SFCI.sol";

--- a/contracts/sfc/SFCState.sol
+++ b/contracts/sfc/SFCState.sol
@@ -108,4 +108,11 @@ contract SFCState is Initializable, Ownable {
     address public voteBookAddress;
 
     address internal sftmFinalizer;
+
+    struct Penalty {
+        uint256 amount;
+        uint256 end;
+    }
+    // delegator => validatorID => penalties info
+    mapping(address => mapping(uint256 => Penalty[])) public getStashedPenalties;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opera-sfc",
-  "version": "3.0.2-rc2",
+  "version": "3.0.4-rc.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "opera-sfc",
-      "version": "3.0.2-rc2",
+      "version": "3.0.4-rc.8",
       "license": "MIT",
       "dependencies": {
         "@nomiclabs/hardhat-ethers": "^2.2.1",
@@ -143,6 +143,32 @@
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
       "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+    },
+    "node_modules/@chainsafe/as-sha256": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz",
+      "integrity": "sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg==",
+      "peer": true
+    },
+    "node_modules/@chainsafe/persistent-merkle-tree": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.4.2.tgz",
+      "integrity": "sha512-lLO3ihKPngXLTus/L7WHKaw9PnNJWizlOF1H9NNzHP6Xvh82vzg9F2bzkXhYIFshMZ2gTCEz8tq6STe7r5NDfQ==",
+      "peer": true,
+      "dependencies": {
+        "@chainsafe/as-sha256": "^0.3.1"
+      }
+    },
+    "node_modules/@chainsafe/ssz": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.9.4.tgz",
+      "integrity": "sha512-77Qtg2N1ayqs4Bg/wvnWfg5Bta7iy7IRh8XqXh7oNMeP2HBbBwx8m6yTpA8p0EHItWPEBkgZd5S5/LSlp3GXuQ==",
+      "peer": true,
+      "dependencies": {
+        "@chainsafe/as-sha256": "^0.3.1",
+        "@chainsafe/persistent-merkle-tree": "^0.4.2",
+        "case": "^1.6.3"
+      }
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -1279,9 +1305,9 @@
       "peer": true
     },
     "node_modules/@noble/hashes": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
-      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
       "funding": [
         {
           "type": "individual",
@@ -1291,9 +1317,9 @@
       "peer": true
     },
     "node_modules/@noble/secp256k1": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
-      "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
       "funding": [
         {
           "type": "individual",
@@ -1338,34 +1364,36 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-block": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-4.0.0.tgz",
-      "integrity": "sha512-bk8uP8VuexLgyIZAHExH1QEovqx0Lzhc9Ntm63nCRKLHXIZkobaFaeCVwTESV7YkPKUk7NiK11s8ryed4CS9yA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-5.0.2.tgz",
+      "integrity": "sha512-hSe6CuHI4SsSiWWjHDIzWhSiAVpzMUcDRpWYzN0T9l8/Rz7xNn3elwVOJ/tAyS0LqL6vitUD78Uk7lQDXZun7Q==",
       "peer": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "ethereum-cryptography": "0.1.3"
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-trie": "6.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
+        "ethereum-cryptography": "0.1.3",
+        "ethers": "^5.7.1"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-blockchain": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-6.0.0.tgz",
-      "integrity": "sha512-pLFEoea6MWd81QQYSReLlLfH7N9v7lH66JC/NMPN848ySPPQA5renWnE7wPByfQFzNrPBuDDRFFULMDmj1C0xw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-7.0.2.tgz",
+      "integrity": "sha512-8UUsSXJs+MFfIIAKdh3cG16iNmWzWC/91P40sazNvrqhhdR/RtGDlFk2iFTGbBAZPs2+klZVzhRX8m2wvuvz3w==",
       "peer": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-ethash": "^2.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-block": "5.0.2",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-ethash": "3.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-trie": "6.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "abstract-level": "^1.0.3",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
@@ -1416,24 +1444,24 @@
       "peer": true
     },
     "node_modules/@nomicfoundation/ethereumjs-common": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-3.0.0.tgz",
-      "integrity": "sha512-WS7qSshQfxoZOpHG/XqlHEGRG1zmyjYrvmATvc4c62+gZXgre1ymYP8ZNgx/3FyZY0TWe9OjFlKOfLqmgOeYwA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-4.0.2.tgz",
+      "integrity": "sha512-I2WGP3HMGsOoycSdOTSqIaES0ughQTueOsddJ36aYVpI3SN8YSusgRFLwzDJwRFVIYDKx/iJz0sQ5kBHVgdDwg==",
       "peer": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "crc-32": "^1.2.0"
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-ethash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-2.0.0.tgz",
-      "integrity": "sha512-WpDvnRncfDUuXdsAXlI4lXbqUDOA+adYRQaEezIkxqDkc+LDyYDbd/xairmY98GnQzo1zIqsIL6GB5MoMSJDew==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-3.0.2.tgz",
+      "integrity": "sha512-8PfoOQCcIcO9Pylq0Buijuq/O73tmMVURK0OqdjhwqcGHYC2PwhbajDh7GZ55ekB0Px197ajK3PQhpKoiI/UPg==",
       "peer": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-block": "5.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "abstract-level": "^1.0.3",
         "bigint-crypto-utils": "^3.0.23",
         "ethereum-cryptography": "0.1.3"
@@ -1443,15 +1471,15 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-evm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-1.0.0.tgz",
-      "integrity": "sha512-hVS6qRo3V1PLKCO210UfcEQHvlG7GqR8iFzp0yyjTg2TmJQizcChKgWo8KFsdMw6AyoLgLhHGHw4HdlP8a4i+Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-2.0.2.tgz",
+      "integrity": "sha512-rBLcUaUfANJxyOx9HIdMX6uXGin6lANCulIm/pjMgRqfiCRMZie3WKYxTSd8ZE/d+qT+zTedBF4+VHTdTSePmQ==",
       "peer": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@types/async-eventemitter": "^0.2.1",
-        "async-eventemitter": "^0.2.4",
+        "@ethersproject/providers": "^5.7.1",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
         "mcl-wasm": "^0.7.1",
@@ -1485,9 +1513,9 @@
       "peer": true
     },
     "node_modules/@nomicfoundation/ethereumjs-rlp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-4.0.0.tgz",
-      "integrity": "sha512-GaSOGk5QbUk4eBP5qFbpXoZoZUj/NrW7MRa0tKY4Ew4c2HAS0GXArEMAamtFrkazp0BO4K5p2ZCG3b2FmbShmw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.2.tgz",
+      "integrity": "sha512-QwmemBc+MMsHJ1P1QvPl8R8p2aPvvVcKBbvHnQOKBpBztEo0omN0eaob6FeZS/e3y9NSe+mfu3nNFBHszqkjTA==",
       "peer": true,
       "bin": {
         "rlp": "bin/rlp"
@@ -1497,18 +1525,17 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-statemanager": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-1.0.0.tgz",
-      "integrity": "sha512-jCtqFjcd2QejtuAMjQzbil/4NHf5aAWxUc+CvS0JclQpl+7M0bxMofR2AJdtz+P3u0ke2euhYREDiE7iSO31vQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-2.0.2.tgz",
+      "integrity": "sha512-dlKy5dIXLuDubx8Z74sipciZnJTRSV/uHG48RSijhgm1V7eXYFC567xgKtsKiVZB1ViTP9iFL4B6Je0xD6X2OA==",
       "peer": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
-        "functional-red-black-tree": "^1.0.1"
+        "ethers": "^5.7.1",
+        "js-sdsl": "^4.1.4"
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-statemanager/node_modules/debug": {
@@ -1535,13 +1562,14 @@
       "peer": true
     },
     "node_modules/@nomicfoundation/ethereumjs-trie": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-5.0.0.tgz",
-      "integrity": "sha512-LIj5XdE+s+t6WSuq/ttegJzZ1vliwg6wlb+Y9f4RlBpuK35B9K02bO7xU+E6Rgg9RGptkWd6TVLdedTI4eNc2A==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-6.0.2.tgz",
+      "integrity": "sha512-yw8vg9hBeLYk4YNg5MrSJ5H55TLOv2FSWUTROtDtTMMmDGROsAu+0tBjiNGTnKRi400M6cEzoFfa89Fc5k8NTQ==",
       "peer": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
+        "@types/readable-stream": "^2.3.13",
         "ethereum-cryptography": "0.1.3",
         "readable-stream": "^3.6.0"
       },
@@ -1550,9 +1578,9 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-trie/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
@@ -1564,14 +1592,16 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-tx": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-4.0.0.tgz",
-      "integrity": "sha512-Gg3Lir2lNUck43Kp/3x6TfBNwcWC9Z1wYue9Nz3v4xjdcv6oDW9QSMJxqsKw9QEGoBBZ+gqwpW7+F05/rs/g1w==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-5.0.2.tgz",
+      "integrity": "sha512-T+l4/MmTp7VhJeNloMkM+lPU3YMUaXdcXgTGCf8+ZFvV9NYZTRLFekRwlG6/JMmVfIfbrW+dRRJ9A6H5Q/Z64g==",
       "peer": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@chainsafe/ssz": "^0.9.2",
+        "@ethersproject/providers": "^5.7.2",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "ethereum-cryptography": "0.1.3"
       },
       "engines": {
@@ -1579,38 +1609,55 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-util": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-8.0.0.tgz",
-      "integrity": "sha512-2emi0NJ/HmTG+CGY58fa+DQuAoroFeSH9gKu9O6JnwTtlzJtgfTixuoOqLEgyyzZVvwfIpRueuePb8TonL1y+A==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.2.tgz",
+      "integrity": "sha512-4Wu9D3LykbSBWZo8nJCnzVIYGvGCuyiYLIJa9XXNVt1q1jUzHdB+sJvx95VGCpPkCT+IbLecW6yfzy3E1bQrwQ==",
       "peer": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0-beta.2",
+        "@chainsafe/ssz": "^0.10.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
         "ethereum-cryptography": "0.1.3"
       },
       "engines": {
         "node": ">=14"
       }
     },
-    "node_modules/@nomicfoundation/ethereumjs-vm": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-6.0.0.tgz",
-      "integrity": "sha512-JMPxvPQ3fzD063Sg3Tp+UdwUkVxMoo1uML6KSzFhMH3hoQi/LMuXBoEHAoW83/vyNS9BxEe6jm6LmT5xdeEJ6w==",
+    "node_modules/@nomicfoundation/ethereumjs-util/node_modules/@chainsafe/persistent-merkle-tree": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.5.0.tgz",
+      "integrity": "sha512-l0V1b5clxA3iwQLXP40zYjyZYospQLZXzBVIhhr9kDg/1qHZfzzHw0jj4VPBijfYCArZDlPkRi1wZaV2POKeuw==",
       "peer": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@types/async-eventemitter": "^0.2.1",
-        "async-eventemitter": "^0.2.4",
+        "@chainsafe/as-sha256": "^0.3.1"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-util/node_modules/@chainsafe/ssz": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.10.2.tgz",
+      "integrity": "sha512-/NL3Lh8K+0q7A3LsiFq09YXS9fPE+ead2rr7vM2QK8PLzrNsw3uqrif9bpRX5UxgeRjM+vYi+boCM3+GM4ovXg==",
+      "peer": true,
+      "dependencies": {
+        "@chainsafe/as-sha256": "^0.3.1",
+        "@chainsafe/persistent-merkle-tree": "^0.5.0"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-vm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-7.0.2.tgz",
+      "integrity": "sha512-Bj3KZT64j54Tcwr7Qm/0jkeZXJMfdcAtRBedou+Hx0dPOSIgqaIr0vvLwP65TpHbak2DmAq+KJbW2KNtIoFwvA==",
+      "peer": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-block": "5.0.2",
+        "@nomicfoundation/ethereumjs-blockchain": "7.0.2",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-evm": "2.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-statemanager": "2.0.2",
+        "@nomicfoundation/ethereumjs-trie": "6.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
-        "functional-red-black-tree": "^1.0.1",
         "mcl-wasm": "^0.7.1",
         "rustbn.js": "~0.2.0"
       },
@@ -1642,30 +1689,30 @@
       "peer": true
     },
     "node_modules/@nomicfoundation/solidity-analyzer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer/-/solidity-analyzer-0.1.0.tgz",
-      "integrity": "sha512-xGWAiVCGOycvGiP/qrlf9f9eOn7fpNbyJygcB0P21a1MDuVPlKt0Srp7rvtBEutYQ48ouYnRXm33zlRnlTOPHg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer/-/solidity-analyzer-0.1.1.tgz",
+      "integrity": "sha512-1LMtXj1puAxyFusBgUIy5pZk3073cNXYnXUpuNKFghHbIit/xZgbk0AokpUADbNm3gyD6bFWl3LRFh3dhVdREg==",
       "peer": true,
       "engines": {
         "node": ">= 12"
       },
       "optionalDependencies": {
-        "@nomicfoundation/solidity-analyzer-darwin-arm64": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-darwin-x64": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-freebsd-x64": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-linux-arm64-gnu": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-linux-arm64-musl": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-linux-x64-gnu": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-linux-x64-musl": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-win32-arm64-msvc": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-win32-ia32-msvc": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-win32-x64-msvc": "0.1.0"
+        "@nomicfoundation/solidity-analyzer-darwin-arm64": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-darwin-x64": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-freebsd-x64": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-arm64-gnu": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-arm64-musl": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-x64-gnu": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-x64-musl": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-win32-arm64-msvc": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-win32-ia32-msvc": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-win32-x64-msvc": "0.1.1"
       }
     },
     "node_modules/@nomicfoundation/solidity-analyzer-darwin-arm64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.0.tgz",
-      "integrity": "sha512-vEF3yKuuzfMHsZecHQcnkUrqm8mnTWfJeEVFHpg+cO+le96xQA4lAJYdUan8pXZohQxv1fSReQsn4QGNuBNuCw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.1.tgz",
+      "integrity": "sha512-KcTodaQw8ivDZyF+D76FokN/HdpgGpfjc/gFCImdLUyqB6eSWVaZPazMbeAjmfhx3R0zm/NYVzxwAokFKgrc0w==",
       "cpu": [
         "arm64"
       ],
@@ -1679,9 +1726,9 @@
       }
     },
     "node_modules/@nomicfoundation/solidity-analyzer-darwin-x64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-x64/-/solidity-analyzer-darwin-x64-0.1.0.tgz",
-      "integrity": "sha512-dlHeIg0pTL4dB1l9JDwbi/JG6dHQaU1xpDK+ugYO8eJ1kxx9Dh2isEUtA4d02cQAl22cjOHTvifAk96A+ItEHA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-x64/-/solidity-analyzer-darwin-x64-0.1.1.tgz",
+      "integrity": "sha512-XhQG4BaJE6cIbjAVtzGOGbK3sn1BO9W29uhk9J8y8fZF1DYz0Doj8QDMfpMu+A6TjPDs61lbsmeYodIDnfveSA==",
       "cpu": [
         "x64"
       ],
@@ -1695,9 +1742,9 @@
       }
     },
     "node_modules/@nomicfoundation/solidity-analyzer-freebsd-x64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-freebsd-x64/-/solidity-analyzer-freebsd-x64-0.1.0.tgz",
-      "integrity": "sha512-WFCZYMv86WowDA4GiJKnebMQRt3kCcFqHeIomW6NMyqiKqhK1kIZCxSLDYsxqlx396kKLPN1713Q1S8tu68GKg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-freebsd-x64/-/solidity-analyzer-freebsd-x64-0.1.1.tgz",
+      "integrity": "sha512-GHF1VKRdHW3G8CndkwdaeLkVBi5A9u2jwtlS7SLhBc8b5U/GcoL39Q+1CSO3hYqePNP+eV5YI7Zgm0ea6kMHoA==",
       "cpu": [
         "x64"
       ],
@@ -1711,9 +1758,9 @@
       }
     },
     "node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-gnu": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-gnu/-/solidity-analyzer-linux-arm64-gnu-0.1.0.tgz",
-      "integrity": "sha512-DTw6MNQWWlCgc71Pq7CEhEqkb7fZnS7oly13pujs4cMH1sR0JzNk90Mp1zpSCsCs4oKan2ClhMlLKtNat/XRKQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-gnu/-/solidity-analyzer-linux-arm64-gnu-0.1.1.tgz",
+      "integrity": "sha512-g4Cv2fO37ZsUENQ2vwPnZc2zRenHyAxHcyBjKcjaSmmkKrFr64yvzeNO8S3GBFCo90rfochLs99wFVGT/0owpg==",
       "cpu": [
         "arm64"
       ],
@@ -1727,9 +1774,9 @@
       }
     },
     "node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-musl": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-musl/-/solidity-analyzer-linux-arm64-musl-0.1.0.tgz",
-      "integrity": "sha512-wUpUnR/3GV5Da88MhrxXh/lhb9kxh9V3Jya2NpBEhKDIRCDmtXMSqPMXHZmOR9DfCwCvG6vLFPr/+YrPCnUN0w==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-musl/-/solidity-analyzer-linux-arm64-musl-0.1.1.tgz",
+      "integrity": "sha512-WJ3CE5Oek25OGE3WwzK7oaopY8xMw9Lhb0mlYuJl/maZVo+WtP36XoQTb7bW/i8aAdHW5Z+BqrHMux23pvxG3w==",
       "cpu": [
         "arm64"
       ],
@@ -1743,9 +1790,9 @@
       }
     },
     "node_modules/@nomicfoundation/solidity-analyzer-linux-x64-gnu": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-gnu/-/solidity-analyzer-linux-x64-gnu-0.1.0.tgz",
-      "integrity": "sha512-lR0AxK1x/MeKQ/3Pt923kPvwigmGX3OxeU5qNtQ9pj9iucgk4PzhbS3ruUeSpYhUxG50jN4RkIGwUMoev5lguw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-gnu/-/solidity-analyzer-linux-x64-gnu-0.1.1.tgz",
+      "integrity": "sha512-5WN7leSr5fkUBBjE4f3wKENUy9HQStu7HmWqbtknfXkkil+eNWiBV275IOlpXku7v3uLsXTOKpnnGHJYI2qsdA==",
       "cpu": [
         "x64"
       ],
@@ -1759,9 +1806,9 @@
       }
     },
     "node_modules/@nomicfoundation/solidity-analyzer-linux-x64-musl": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-musl/-/solidity-analyzer-linux-x64-musl-0.1.0.tgz",
-      "integrity": "sha512-A1he/8gy/JeBD3FKvmI6WUJrGrI5uWJNr5Xb9WdV+DK0F8msuOqpEByLlnTdLkXMwW7nSl3awvLezOs9xBHJEg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-musl/-/solidity-analyzer-linux-x64-musl-0.1.1.tgz",
+      "integrity": "sha512-KdYMkJOq0SYPQMmErv/63CwGwMm5XHenEna9X9aB8mQmhDBrYrlAOSsIPgFCUSL0hjxE3xHP65/EPXR/InD2+w==",
       "cpu": [
         "x64"
       ],
@@ -1775,9 +1822,9 @@
       }
     },
     "node_modules/@nomicfoundation/solidity-analyzer-win32-arm64-msvc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-arm64-msvc/-/solidity-analyzer-win32-arm64-msvc-0.1.0.tgz",
-      "integrity": "sha512-7x5SXZ9R9H4SluJZZP8XPN+ju7Mx+XeUMWZw7ZAqkdhP5mK19I4vz3x0zIWygmfE8RT7uQ5xMap0/9NPsO+ykw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-arm64-msvc/-/solidity-analyzer-win32-arm64-msvc-0.1.1.tgz",
+      "integrity": "sha512-VFZASBfl4qiBYwW5xeY20exWhmv6ww9sWu/krWSesv3q5hA0o1JuzmPHR4LPN6SUZj5vcqci0O6JOL8BPw+APg==",
       "cpu": [
         "arm64"
       ],
@@ -1791,9 +1838,9 @@
       }
     },
     "node_modules/@nomicfoundation/solidity-analyzer-win32-ia32-msvc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-ia32-msvc/-/solidity-analyzer-win32-ia32-msvc-0.1.0.tgz",
-      "integrity": "sha512-m7w3xf+hnE774YRXu+2mGV7RiF3QJtUoiYU61FascCkQhX3QMQavh7saH/vzb2jN5D24nT/jwvaHYX/MAM9zUw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-ia32-msvc/-/solidity-analyzer-win32-ia32-msvc-0.1.1.tgz",
+      "integrity": "sha512-JnFkYuyCSA70j6Si6cS1A9Gh1aHTEb8kOTBApp/c7NRTFGNMH8eaInKlyuuiIbvYFhlXW4LicqyYuWNNq9hkpQ==",
       "cpu": [
         "ia32"
       ],
@@ -1807,9 +1854,9 @@
       }
     },
     "node_modules/@nomicfoundation/solidity-analyzer-win32-x64-msvc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-x64-msvc/-/solidity-analyzer-win32-x64-msvc-0.1.0.tgz",
-      "integrity": "sha512-xCuybjY0sLJQnJhupiFAXaek2EqF0AP0eBjgzaalPXSNvCEN6ZYHvUzdA50ENDVeSYFXcUsYf3+FsD3XKaeptA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-x64-msvc/-/solidity-analyzer-win32-x64-msvc-0.1.1.tgz",
+      "integrity": "sha512-HrVJr6+WjIXGnw3Q9u6KQcbZCtk0caVWhCdFADySvRyUxJ8PnzlaP+MhwNE8oyT8OZ6ejHBRrrgjSqDCFXGirw==",
       "cpu": [
         "x64"
       ],
@@ -1835,6 +1882,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.1.3.tgz",
       "integrity": "sha512-UeNO97j0lwOHqX7mrH6SfQQBdXq1Ng6eFr7uJKuQOrq2UVTWGD70lE5QO4fAFVPz9ao+xlNpMyIqSR7+OaDR+Q==",
+      "deprecated": "The @nomiclabs/hardhat-etherscan package is deprecated, please use @nomicfoundation/hardhat-verify instead",
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@ethersproject/address": "^5.0.2",
@@ -4008,21 +4056,18 @@
       "dev": true
     },
     "node_modules/@scure/base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
-      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "peer": true
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
+      "integrity": "sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ==",
+      "peer": true,
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.0.tgz",
-      "integrity": "sha512-ftTW3kKX54YXLCxH6BB7oEEoJfoE2pIgw7MINKAs5PsS6nqKPuKk1haTF/EuHmYqG330t5GSrdmtRuHaY1a62Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz",
+      "integrity": "sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==",
       "funding": [
         {
           "type": "individual",
@@ -4031,15 +4076,15 @@
       ],
       "peer": true,
       "dependencies": {
-        "@noble/hashes": "~1.1.1",
-        "@noble/secp256k1": "~1.6.0",
+        "@noble/hashes": "~1.2.0",
+        "@noble/secp256k1": "~1.7.0",
         "@scure/base": "~1.1.0"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.0.tgz",
-      "integrity": "sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz",
+      "integrity": "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==",
       "funding": [
         {
           "type": "individual",
@@ -4048,7 +4093,7 @@
       ],
       "peer": true,
       "dependencies": {
-        "@noble/hashes": "~1.1.1",
+        "@noble/hashes": "~1.2.0",
         "@scure/base": "~1.1.0"
       }
     },
@@ -6424,12 +6469,6 @@
         "typechain": "^3.0.0"
       }
     },
-    "node_modules/@types/async-eventemitter": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@types/async-eventemitter/-/async-eventemitter-0.2.1.tgz",
-      "integrity": "sha512-M2P4Ng26QbAeITiH7w1d7OxtldgfAe0wobpyJzVK/XOb0cUGKU2R4pfAhqcJBXAe2ife5ZOhSv4wk7p+ffURtg==",
-      "peer": true
-    },
     "node_modules/@types/bignumber.js": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-5.0.0.tgz",
@@ -6519,19 +6558,19 @@
       "integrity": "sha512-koZJ89uLZufDvToeWO5BrC4CR4OUfHnUz2qoPs/daQH6qq3IN62QFxCTZ+bKaCE0xaoCAJYE4AXre8AbghCrhg=="
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
       "peer": true,
       "dependencies": {
         "@types/node": "*",
-        "form-data": "^3.0.0"
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/node-fetch/node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -6551,10 +6590,20 @@
       }
     },
     "node_modules/@types/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
       "peer": true
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "0.0.8",
@@ -6628,18 +6677,6 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
       "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
       "dev": true
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "peer": true,
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
     },
     "node_modules/abortcontroller-polyfill": {
       "version": "1.7.5",
@@ -7064,17 +7101,9 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
       "dependencies": {
         "lodash": "^4.17.14"
-      }
-    },
-    "node_modules/async-eventemitter": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
-      "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
-      "peer": true,
-      "dependencies": {
-        "async": "^2.4.0"
       }
     },
     "node_modules/async-limiter": {
@@ -7086,6 +7115,15 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -7870,24 +7908,12 @@
       }
     },
     "node_modules/bigint-crypto-utils": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.1.7.tgz",
-      "integrity": "sha512-zpCQpIE2Oy5WIQpjC9iYZf8Uh9QqoS51ZCooAcNvzv1AQ3VWdT52D0ksr1+/faeK8HVIej1bxXcP75YcqH3KPA==",
-      "peer": true,
-      "dependencies": {
-        "bigint-mod-arith": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10.4.0"
-      }
-    },
-    "node_modules/bigint-mod-arith": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bigint-mod-arith/-/bigint-mod-arith-3.1.2.tgz",
-      "integrity": "sha512-nx8J8bBeiRR+NlsROFH9jHswW5HO8mgfOSqW0AmjicMMvaONDa8AO+5ViKDUUNytBPWiwfvZP4/Bj4Y3lUfvgQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.3.0.tgz",
+      "integrity": "sha512-jOTSb+drvEDxEq6OuUybOAv/xxoh3cuYRUIPyu8sSHQNKM303UQ2R1DAo45o1AkcIXw6fzbaFI1+xGGdaXs2lg==",
       "peer": true,
       "engines": {
-        "node": ">=10.4.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/bignumber.js": {
@@ -8362,6 +8388,15 @@
       "integrity": "sha512-ic/jXfa6tgiPBAISWk16jRI2q8YfjxHnSG7ddSL1ptrIP8Uy11SayFrjXRAk3NumHpDb21fdTkbTxb/hOrFrnQ==",
       "dev": true
     },
+    "node_modules/case": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/case/-/case-1.6.3.tgz",
+      "integrity": "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -8601,16 +8636,16 @@
       "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
     },
     "node_modules/classic-level": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
-      "integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.3.0.tgz",
+      "integrity": "sha512-iwFAJQYtqRTRM0F6L8h4JCt00ZSGdOyqh7yVrhhjrOpFhmBjNlRUey64MCiyo6UmQHMJ+No3c81nujPv+n9yrg==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
         "abstract-level": "^1.0.2",
         "catering": "^2.1.0",
         "module-error": "^1.0.1",
-        "napi-macros": "~2.0.0",
+        "napi-macros": "^2.2.2",
         "node-gyp-build": "^4.3.0"
       },
       "engines": {
@@ -9673,12 +9708,13 @@
       }
     },
     "node_modules/enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "peer": true,
       "dependencies": {
-        "ansi-colors": "^4.1.1"
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -9691,6 +9727,27 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/enquirer/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/enquirer/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ent": {
@@ -10491,7 +10548,8 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
       "integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA==",
-      "deprecated": "New package name format for new versions: @ethereumjs/common. Please update."
+      "deprecated": "New package name format for new versions: @ethereumjs/common. Please update.",
+      "dev": true
     },
     "node_modules/ethereumjs-testrpc-sc": {
       "version": "6.5.1-sc.1",
@@ -10510,16 +10568,6 @@
       },
       "bin": {
         "testrpc-sc": "cli.js"
-      }
-    },
-    "node_modules/ethereumjs-testrpc-sc/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ethereumjs-testrpc-sc/node_modules/ansi-styles": {
@@ -10686,16 +10734,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/ethereumjs-testrpc-sc/node_modules/code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ethereumjs-testrpc-sc/node_modules/color-convert": {
@@ -11178,16 +11216,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/ethereumjs-testrpc-sc/node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ethereumjs-testrpc-sc/node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -11479,45 +11507,6 @@
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/ethereumjs-testrpc-sc/node_modules/string-width": {
-      "version": "1.0.2",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ethereumjs-testrpc-sc/node_modules/string-width/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ethereumjs-testrpc-sc/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ethereumjs-testrpc-sc/node_modules/strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -11691,6 +11680,7 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
       "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
       "deprecated": "New package name format for new versions: @ethereumjs/tx. Please update.",
+      "dev": true,
       "dependencies": {
         "ethereumjs-common": "^1.5.0",
         "ethereumjs-util": "^6.0.0"
@@ -11821,15 +11811,6 @@
       "engines": {
         "node": ">=6.5.0",
         "npm": ">=3"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {
@@ -22755,28 +22736,27 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "2.12.4",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.12.4.tgz",
-      "integrity": "sha512-rc9S2U/4M+77LxW1Kg7oqMMmjl81tzn5rNFARhbXKUA1am/nhfMJEujOjuKvt+ZGMiZ11PYSe8gyIpB/aRNDgw==",
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.19.3.tgz",
+      "integrity": "sha512-zUvfILiu1O7W1a+t5E1nCJ6z1danRLNizQkSEQCCgDYcRx13AGXtH1MVZajKmdLmXIjKAPReTp/8JQQ4ZHaX3g==",
       "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@nomicfoundation/ethereumjs-vm": "^6.0.0",
+        "@nomicfoundation/ethereumjs-block": "5.0.2",
+        "@nomicfoundation/ethereumjs-blockchain": "7.0.2",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-evm": "2.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-statemanager": "2.0.2",
+        "@nomicfoundation/ethereumjs-trie": "6.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
+        "@nomicfoundation/ethereumjs-vm": "7.0.2",
         "@nomicfoundation/solidity-analyzer": "^0.1.0",
         "@sentry/node": "^5.18.1",
         "@types/bn.js": "^5.1.0",
         "@types/lru-cache": "^5.1.0",
-        "abort-controller": "^3.0.0",
         "adm-zip": "^0.4.16",
         "aggregate-error": "^3.0.0",
         "ansi-escapes": "^4.3.0",
@@ -22799,7 +22779,6 @@
         "mnemonist": "^0.38.0",
         "mocha": "^10.0.0",
         "p-map": "^4.0.0",
-        "qs": "^6.7.0",
         "raw-body": "^2.4.1",
         "resolve": "1.17.0",
         "semver": "^6.3.0",
@@ -22807,15 +22786,12 @@
         "source-map-support": "^0.5.13",
         "stacktrace-parser": "^0.1.10",
         "tsort": "0.0.1",
-        "undici": "^5.4.0",
+        "undici": "^5.14.0",
         "uuid": "^8.3.2",
         "ws": "^7.4.6"
       },
       "bin": {
-        "hardhat": "internal/cli/cli.js"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || ^18.0.0"
+        "hardhat": "internal/cli/bootstrap.js"
       },
       "peerDependencies": {
         "ts-node": "*",
@@ -22934,9 +22910,9 @@
       }
     },
     "node_modules/hardhat/node_modules/@types/bn.js": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
-      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.5.tgz",
+      "integrity": "sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==",
       "peer": true,
       "dependencies": {
         "@types/node": "*"
@@ -23010,15 +22986,15 @@
       }
     },
     "node_modules/hardhat/node_modules/ethereum-cryptography": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz",
-      "integrity": "sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
+      "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
       "peer": true,
       "dependencies": {
-        "@noble/hashes": "1.1.2",
-        "@noble/secp256k1": "1.6.3",
-        "@scure/bip32": "1.1.0",
-        "@scure/bip39": "1.1.0"
+        "@noble/hashes": "1.2.0",
+        "@noble/secp256k1": "1.7.1",
+        "@scure/bip32": "1.1.5",
+        "@scure/bip39": "1.1.1"
       }
     },
     "node_modules/hardhat/node_modules/http-errors": {
@@ -23053,9 +23029,9 @@
       }
     },
     "node_modules/hardhat/node_modules/keccak": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
-      "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
+      "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
@@ -23074,9 +23050,9 @@
       "peer": true
     },
     "node_modules/hardhat/node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "peer": true,
       "dependencies": {
         "bytes": "3.1.2",
@@ -23089,9 +23065,9 @@
       }
     },
     "node_modules/hardhat/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
@@ -23124,9 +23100,9 @@
       }
     },
     "node_modules/hardhat/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "peer": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -23175,9 +23151,9 @@
       }
     },
     "node_modules/hardhat/node_modules/solc/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "peer": true,
       "bin": {
         "semver": "bin/semver"
@@ -23663,9 +23639,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
+      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
       "peer": true
     },
     "node_modules/import-fresh": {
@@ -24340,6 +24316,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/js-sdsl": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.2.tgz",
+      "integrity": "sha512-dwXFwByc/ajSV6m5bcKAPwe4yDDF6D614pxmIi5odytzxRlwqF6nwoiCek80Ixc7Cvma5awClxrzFtxCQvcM8w==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/js-sha3": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
@@ -24888,6 +24874,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
       "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -25461,9 +25448,9 @@
       }
     },
     "node_modules/napi-macros": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
-      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
+      "integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
       "peer": true
     },
     "node_modules/natural-compare": {
@@ -28208,7 +28195,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
       "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -28617,16 +28603,16 @@
       }
     },
     "node_modules/patch-package": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.0.tgz",
-      "integrity": "sha512-tC3EqJmo74yKqfsMzELaFwxOAu6FH6t+FzFOsnWAuARm7/n2xB5AOeOueE221eM9gtMuIKMKpF9tBy/X2mNP0Q==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.1.tgz",
+      "integrity": "sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==",
       "peer": true,
       "dependencies": {
         "@yarnpkg/lockfile": "^1.1.0",
         "chalk": "^4.1.2",
         "cross-spawn": "^6.0.5",
         "find-yarn-workspace-root": "^2.0.0",
-        "fs-extra": "^7.0.1",
+        "fs-extra": "^9.0.0",
         "is-ci": "^2.0.0",
         "klaw-sync": "^6.0.0",
         "minimist": "^1.2.6",
@@ -28694,6 +28680,21 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "peer": true
     },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "peer": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/patch-package/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -28701,6 +28702,18 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/patch-package/node_modules/slash": {
@@ -28722,6 +28735,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/path-browserify": {
@@ -28967,7 +28989,8 @@
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -29047,16 +29070,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "peer": true,
-      "engines": {
-        "node": ">=0.4.x"
       }
     },
     "node_modules/queue-microtask": {
@@ -29885,7 +29898,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -30820,6 +30832,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -30828,6 +30841,7 @@
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
       "dependencies": {
         "source-map": "^0.5.6"
       }
@@ -31701,9 +31715,9 @@
       }
     },
     "node_modules/ts-generator/node_modules/prettier": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
-      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -31894,16 +31908,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typical": {
@@ -32005,13 +32019,13 @@
       }
     },
     "node_modules/url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
+      "integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
       "peer": true,
       "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
+        "punycode": "^1.4.1",
+        "qs": "^6.11.2"
       }
     },
     "node_modules/url-parse-lax": {
@@ -32039,10 +32053,25 @@
       }
     },
     "node_modules/url/node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "peer": true
+    },
+    "node_modules/url/node_modules/qs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+      "peer": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/useragent": {
       "version": "2.3.0",
@@ -33260,7 +33289,8 @@
     "node_modules/yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -33457,6 +33487,32 @@
           "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
           "dev": true
         }
+      }
+    },
+    "@chainsafe/as-sha256": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz",
+      "integrity": "sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg==",
+      "peer": true
+    },
+    "@chainsafe/persistent-merkle-tree": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.4.2.tgz",
+      "integrity": "sha512-lLO3ihKPngXLTus/L7WHKaw9PnNJWizlOF1H9NNzHP6Xvh82vzg9F2bzkXhYIFshMZ2gTCEz8tq6STe7r5NDfQ==",
+      "peer": true,
+      "requires": {
+        "@chainsafe/as-sha256": "^0.3.1"
+      }
+    },
+    "@chainsafe/ssz": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.9.4.tgz",
+      "integrity": "sha512-77Qtg2N1ayqs4Bg/wvnWfg5Bta7iy7IRh8XqXh7oNMeP2HBbBwx8m6yTpA8p0EHItWPEBkgZd5S5/LSlp3GXuQ==",
+      "peer": true,
+      "requires": {
+        "@chainsafe/as-sha256": "^0.3.1",
+        "@chainsafe/persistent-merkle-tree": "^0.4.2",
+        "case": "^1.6.3"
       }
     },
     "@colors/colors": {
@@ -34258,15 +34314,15 @@
       }
     },
     "@noble/hashes": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
-      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
       "peer": true
     },
     "@noble/secp256k1": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
-      "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
       "peer": true
     },
     "@nodelib/fs.scandir": {
@@ -34296,31 +34352,33 @@
       }
     },
     "@nomicfoundation/ethereumjs-block": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-4.0.0.tgz",
-      "integrity": "sha512-bk8uP8VuexLgyIZAHExH1QEovqx0Lzhc9Ntm63nCRKLHXIZkobaFaeCVwTESV7YkPKUk7NiK11s8ryed4CS9yA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-5.0.2.tgz",
+      "integrity": "sha512-hSe6CuHI4SsSiWWjHDIzWhSiAVpzMUcDRpWYzN0T9l8/Rz7xNn3elwVOJ/tAyS0LqL6vitUD78Uk7lQDXZun7Q==",
       "peer": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "ethereum-cryptography": "0.1.3"
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-trie": "6.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
+        "ethereum-cryptography": "0.1.3",
+        "ethers": "^5.7.1"
       }
     },
     "@nomicfoundation/ethereumjs-blockchain": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-6.0.0.tgz",
-      "integrity": "sha512-pLFEoea6MWd81QQYSReLlLfH7N9v7lH66JC/NMPN848ySPPQA5renWnE7wPByfQFzNrPBuDDRFFULMDmj1C0xw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-7.0.2.tgz",
+      "integrity": "sha512-8UUsSXJs+MFfIIAKdh3cG16iNmWzWC/91P40sazNvrqhhdR/RtGDlFk2iFTGbBAZPs2+klZVzhRX8m2wvuvz3w==",
       "peer": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-ethash": "^2.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-block": "5.0.2",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-ethash": "3.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-trie": "6.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "abstract-level": "^1.0.3",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
@@ -34362,39 +34420,39 @@
       }
     },
     "@nomicfoundation/ethereumjs-common": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-3.0.0.tgz",
-      "integrity": "sha512-WS7qSshQfxoZOpHG/XqlHEGRG1zmyjYrvmATvc4c62+gZXgre1ymYP8ZNgx/3FyZY0TWe9OjFlKOfLqmgOeYwA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-4.0.2.tgz",
+      "integrity": "sha512-I2WGP3HMGsOoycSdOTSqIaES0ughQTueOsddJ36aYVpI3SN8YSusgRFLwzDJwRFVIYDKx/iJz0sQ5kBHVgdDwg==",
       "peer": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "crc-32": "^1.2.0"
       }
     },
     "@nomicfoundation/ethereumjs-ethash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-2.0.0.tgz",
-      "integrity": "sha512-WpDvnRncfDUuXdsAXlI4lXbqUDOA+adYRQaEezIkxqDkc+LDyYDbd/xairmY98GnQzo1zIqsIL6GB5MoMSJDew==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-3.0.2.tgz",
+      "integrity": "sha512-8PfoOQCcIcO9Pylq0Buijuq/O73tmMVURK0OqdjhwqcGHYC2PwhbajDh7GZ55ekB0Px197ajK3PQhpKoiI/UPg==",
       "peer": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-block": "5.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "abstract-level": "^1.0.3",
         "bigint-crypto-utils": "^3.0.23",
         "ethereum-cryptography": "0.1.3"
       }
     },
     "@nomicfoundation/ethereumjs-evm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-1.0.0.tgz",
-      "integrity": "sha512-hVS6qRo3V1PLKCO210UfcEQHvlG7GqR8iFzp0yyjTg2TmJQizcChKgWo8KFsdMw6AyoLgLhHGHw4HdlP8a4i+Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-2.0.2.tgz",
+      "integrity": "sha512-rBLcUaUfANJxyOx9HIdMX6uXGin6lANCulIm/pjMgRqfiCRMZie3WKYxTSd8ZE/d+qT+zTedBF4+VHTdTSePmQ==",
       "peer": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@types/async-eventemitter": "^0.2.1",
-        "async-eventemitter": "^0.2.4",
+        "@ethersproject/providers": "^5.7.1",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
         "mcl-wasm": "^0.7.1",
@@ -34419,24 +34477,23 @@
       }
     },
     "@nomicfoundation/ethereumjs-rlp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-4.0.0.tgz",
-      "integrity": "sha512-GaSOGk5QbUk4eBP5qFbpXoZoZUj/NrW7MRa0tKY4Ew4c2HAS0GXArEMAamtFrkazp0BO4K5p2ZCG3b2FmbShmw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.2.tgz",
+      "integrity": "sha512-QwmemBc+MMsHJ1P1QvPl8R8p2aPvvVcKBbvHnQOKBpBztEo0omN0eaob6FeZS/e3y9NSe+mfu3nNFBHszqkjTA==",
       "peer": true
     },
     "@nomicfoundation/ethereumjs-statemanager": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-1.0.0.tgz",
-      "integrity": "sha512-jCtqFjcd2QejtuAMjQzbil/4NHf5aAWxUc+CvS0JclQpl+7M0bxMofR2AJdtz+P3u0ke2euhYREDiE7iSO31vQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-2.0.2.tgz",
+      "integrity": "sha512-dlKy5dIXLuDubx8Z74sipciZnJTRSV/uHG48RSijhgm1V7eXYFC567xgKtsKiVZB1ViTP9iFL4B6Je0xD6X2OA==",
       "peer": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
-        "functional-red-black-tree": "^1.0.1"
+        "ethers": "^5.7.1",
+        "js-sdsl": "^4.1.4"
       },
       "dependencies": {
         "debug": {
@@ -34457,21 +34514,22 @@
       }
     },
     "@nomicfoundation/ethereumjs-trie": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-5.0.0.tgz",
-      "integrity": "sha512-LIj5XdE+s+t6WSuq/ttegJzZ1vliwg6wlb+Y9f4RlBpuK35B9K02bO7xU+E6Rgg9RGptkWd6TVLdedTI4eNc2A==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-6.0.2.tgz",
+      "integrity": "sha512-yw8vg9hBeLYk4YNg5MrSJ5H55TLOv2FSWUTROtDtTMMmDGROsAu+0tBjiNGTnKRi400M6cEzoFfa89Fc5k8NTQ==",
       "peer": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
+        "@types/readable-stream": "^2.3.13",
         "ethereum-cryptography": "0.1.3",
         "readable-stream": "^3.6.0"
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
           "peer": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -34482,47 +34540,68 @@
       }
     },
     "@nomicfoundation/ethereumjs-tx": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-4.0.0.tgz",
-      "integrity": "sha512-Gg3Lir2lNUck43Kp/3x6TfBNwcWC9Z1wYue9Nz3v4xjdcv6oDW9QSMJxqsKw9QEGoBBZ+gqwpW7+F05/rs/g1w==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-5.0.2.tgz",
+      "integrity": "sha512-T+l4/MmTp7VhJeNloMkM+lPU3YMUaXdcXgTGCf8+ZFvV9NYZTRLFekRwlG6/JMmVfIfbrW+dRRJ9A6H5Q/Z64g==",
       "peer": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@chainsafe/ssz": "^0.9.2",
+        "@ethersproject/providers": "^5.7.2",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "ethereum-cryptography": "0.1.3"
       }
     },
     "@nomicfoundation/ethereumjs-util": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-8.0.0.tgz",
-      "integrity": "sha512-2emi0NJ/HmTG+CGY58fa+DQuAoroFeSH9gKu9O6JnwTtlzJtgfTixuoOqLEgyyzZVvwfIpRueuePb8TonL1y+A==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.2.tgz",
+      "integrity": "sha512-4Wu9D3LykbSBWZo8nJCnzVIYGvGCuyiYLIJa9XXNVt1q1jUzHdB+sJvx95VGCpPkCT+IbLecW6yfzy3E1bQrwQ==",
       "peer": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0-beta.2",
+        "@chainsafe/ssz": "^0.10.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
         "ethereum-cryptography": "0.1.3"
+      },
+      "dependencies": {
+        "@chainsafe/persistent-merkle-tree": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.5.0.tgz",
+          "integrity": "sha512-l0V1b5clxA3iwQLXP40zYjyZYospQLZXzBVIhhr9kDg/1qHZfzzHw0jj4VPBijfYCArZDlPkRi1wZaV2POKeuw==",
+          "peer": true,
+          "requires": {
+            "@chainsafe/as-sha256": "^0.3.1"
+          }
+        },
+        "@chainsafe/ssz": {
+          "version": "0.10.2",
+          "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.10.2.tgz",
+          "integrity": "sha512-/NL3Lh8K+0q7A3LsiFq09YXS9fPE+ead2rr7vM2QK8PLzrNsw3uqrif9bpRX5UxgeRjM+vYi+boCM3+GM4ovXg==",
+          "peer": true,
+          "requires": {
+            "@chainsafe/as-sha256": "^0.3.1",
+            "@chainsafe/persistent-merkle-tree": "^0.5.0"
+          }
+        }
       }
     },
     "@nomicfoundation/ethereumjs-vm": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-6.0.0.tgz",
-      "integrity": "sha512-JMPxvPQ3fzD063Sg3Tp+UdwUkVxMoo1uML6KSzFhMH3hoQi/LMuXBoEHAoW83/vyNS9BxEe6jm6LmT5xdeEJ6w==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-7.0.2.tgz",
+      "integrity": "sha512-Bj3KZT64j54Tcwr7Qm/0jkeZXJMfdcAtRBedou+Hx0dPOSIgqaIr0vvLwP65TpHbak2DmAq+KJbW2KNtIoFwvA==",
       "peer": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@types/async-eventemitter": "^0.2.1",
-        "async-eventemitter": "^0.2.4",
+        "@nomicfoundation/ethereumjs-block": "5.0.2",
+        "@nomicfoundation/ethereumjs-blockchain": "7.0.2",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-evm": "2.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-statemanager": "2.0.2",
+        "@nomicfoundation/ethereumjs-trie": "6.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
-        "functional-red-black-tree": "^1.0.1",
         "mcl-wasm": "^0.7.1",
         "rustbn.js": "~0.2.0"
       },
@@ -34545,90 +34624,90 @@
       }
     },
     "@nomicfoundation/solidity-analyzer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer/-/solidity-analyzer-0.1.0.tgz",
-      "integrity": "sha512-xGWAiVCGOycvGiP/qrlf9f9eOn7fpNbyJygcB0P21a1MDuVPlKt0Srp7rvtBEutYQ48ouYnRXm33zlRnlTOPHg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer/-/solidity-analyzer-0.1.1.tgz",
+      "integrity": "sha512-1LMtXj1puAxyFusBgUIy5pZk3073cNXYnXUpuNKFghHbIit/xZgbk0AokpUADbNm3gyD6bFWl3LRFh3dhVdREg==",
       "peer": true,
       "requires": {
-        "@nomicfoundation/solidity-analyzer-darwin-arm64": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-darwin-x64": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-freebsd-x64": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-linux-arm64-gnu": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-linux-arm64-musl": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-linux-x64-gnu": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-linux-x64-musl": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-win32-arm64-msvc": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-win32-ia32-msvc": "0.1.0",
-        "@nomicfoundation/solidity-analyzer-win32-x64-msvc": "0.1.0"
+        "@nomicfoundation/solidity-analyzer-darwin-arm64": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-darwin-x64": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-freebsd-x64": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-arm64-gnu": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-arm64-musl": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-x64-gnu": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-x64-musl": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-win32-arm64-msvc": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-win32-ia32-msvc": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-win32-x64-msvc": "0.1.1"
       }
     },
     "@nomicfoundation/solidity-analyzer-darwin-arm64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.0.tgz",
-      "integrity": "sha512-vEF3yKuuzfMHsZecHQcnkUrqm8mnTWfJeEVFHpg+cO+le96xQA4lAJYdUan8pXZohQxv1fSReQsn4QGNuBNuCw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.1.tgz",
+      "integrity": "sha512-KcTodaQw8ivDZyF+D76FokN/HdpgGpfjc/gFCImdLUyqB6eSWVaZPazMbeAjmfhx3R0zm/NYVzxwAokFKgrc0w==",
       "optional": true,
       "peer": true
     },
     "@nomicfoundation/solidity-analyzer-darwin-x64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-x64/-/solidity-analyzer-darwin-x64-0.1.0.tgz",
-      "integrity": "sha512-dlHeIg0pTL4dB1l9JDwbi/JG6dHQaU1xpDK+ugYO8eJ1kxx9Dh2isEUtA4d02cQAl22cjOHTvifAk96A+ItEHA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-x64/-/solidity-analyzer-darwin-x64-0.1.1.tgz",
+      "integrity": "sha512-XhQG4BaJE6cIbjAVtzGOGbK3sn1BO9W29uhk9J8y8fZF1DYz0Doj8QDMfpMu+A6TjPDs61lbsmeYodIDnfveSA==",
       "optional": true,
       "peer": true
     },
     "@nomicfoundation/solidity-analyzer-freebsd-x64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-freebsd-x64/-/solidity-analyzer-freebsd-x64-0.1.0.tgz",
-      "integrity": "sha512-WFCZYMv86WowDA4GiJKnebMQRt3kCcFqHeIomW6NMyqiKqhK1kIZCxSLDYsxqlx396kKLPN1713Q1S8tu68GKg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-freebsd-x64/-/solidity-analyzer-freebsd-x64-0.1.1.tgz",
+      "integrity": "sha512-GHF1VKRdHW3G8CndkwdaeLkVBi5A9u2jwtlS7SLhBc8b5U/GcoL39Q+1CSO3hYqePNP+eV5YI7Zgm0ea6kMHoA==",
       "optional": true,
       "peer": true
     },
     "@nomicfoundation/solidity-analyzer-linux-arm64-gnu": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-gnu/-/solidity-analyzer-linux-arm64-gnu-0.1.0.tgz",
-      "integrity": "sha512-DTw6MNQWWlCgc71Pq7CEhEqkb7fZnS7oly13pujs4cMH1sR0JzNk90Mp1zpSCsCs4oKan2ClhMlLKtNat/XRKQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-gnu/-/solidity-analyzer-linux-arm64-gnu-0.1.1.tgz",
+      "integrity": "sha512-g4Cv2fO37ZsUENQ2vwPnZc2zRenHyAxHcyBjKcjaSmmkKrFr64yvzeNO8S3GBFCo90rfochLs99wFVGT/0owpg==",
       "optional": true,
       "peer": true
     },
     "@nomicfoundation/solidity-analyzer-linux-arm64-musl": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-musl/-/solidity-analyzer-linux-arm64-musl-0.1.0.tgz",
-      "integrity": "sha512-wUpUnR/3GV5Da88MhrxXh/lhb9kxh9V3Jya2NpBEhKDIRCDmtXMSqPMXHZmOR9DfCwCvG6vLFPr/+YrPCnUN0w==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-musl/-/solidity-analyzer-linux-arm64-musl-0.1.1.tgz",
+      "integrity": "sha512-WJ3CE5Oek25OGE3WwzK7oaopY8xMw9Lhb0mlYuJl/maZVo+WtP36XoQTb7bW/i8aAdHW5Z+BqrHMux23pvxG3w==",
       "optional": true,
       "peer": true
     },
     "@nomicfoundation/solidity-analyzer-linux-x64-gnu": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-gnu/-/solidity-analyzer-linux-x64-gnu-0.1.0.tgz",
-      "integrity": "sha512-lR0AxK1x/MeKQ/3Pt923kPvwigmGX3OxeU5qNtQ9pj9iucgk4PzhbS3ruUeSpYhUxG50jN4RkIGwUMoev5lguw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-gnu/-/solidity-analyzer-linux-x64-gnu-0.1.1.tgz",
+      "integrity": "sha512-5WN7leSr5fkUBBjE4f3wKENUy9HQStu7HmWqbtknfXkkil+eNWiBV275IOlpXku7v3uLsXTOKpnnGHJYI2qsdA==",
       "optional": true,
       "peer": true
     },
     "@nomicfoundation/solidity-analyzer-linux-x64-musl": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-musl/-/solidity-analyzer-linux-x64-musl-0.1.0.tgz",
-      "integrity": "sha512-A1he/8gy/JeBD3FKvmI6WUJrGrI5uWJNr5Xb9WdV+DK0F8msuOqpEByLlnTdLkXMwW7nSl3awvLezOs9xBHJEg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-musl/-/solidity-analyzer-linux-x64-musl-0.1.1.tgz",
+      "integrity": "sha512-KdYMkJOq0SYPQMmErv/63CwGwMm5XHenEna9X9aB8mQmhDBrYrlAOSsIPgFCUSL0hjxE3xHP65/EPXR/InD2+w==",
       "optional": true,
       "peer": true
     },
     "@nomicfoundation/solidity-analyzer-win32-arm64-msvc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-arm64-msvc/-/solidity-analyzer-win32-arm64-msvc-0.1.0.tgz",
-      "integrity": "sha512-7x5SXZ9R9H4SluJZZP8XPN+ju7Mx+XeUMWZw7ZAqkdhP5mK19I4vz3x0zIWygmfE8RT7uQ5xMap0/9NPsO+ykw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-arm64-msvc/-/solidity-analyzer-win32-arm64-msvc-0.1.1.tgz",
+      "integrity": "sha512-VFZASBfl4qiBYwW5xeY20exWhmv6ww9sWu/krWSesv3q5hA0o1JuzmPHR4LPN6SUZj5vcqci0O6JOL8BPw+APg==",
       "optional": true,
       "peer": true
     },
     "@nomicfoundation/solidity-analyzer-win32-ia32-msvc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-ia32-msvc/-/solidity-analyzer-win32-ia32-msvc-0.1.0.tgz",
-      "integrity": "sha512-m7w3xf+hnE774YRXu+2mGV7RiF3QJtUoiYU61FascCkQhX3QMQavh7saH/vzb2jN5D24nT/jwvaHYX/MAM9zUw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-ia32-msvc/-/solidity-analyzer-win32-ia32-msvc-0.1.1.tgz",
+      "integrity": "sha512-JnFkYuyCSA70j6Si6cS1A9Gh1aHTEb8kOTBApp/c7NRTFGNMH8eaInKlyuuiIbvYFhlXW4LicqyYuWNNq9hkpQ==",
       "optional": true,
       "peer": true
     },
     "@nomicfoundation/solidity-analyzer-win32-x64-msvc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-x64-msvc/-/solidity-analyzer-win32-x64-msvc-0.1.0.tgz",
-      "integrity": "sha512-xCuybjY0sLJQnJhupiFAXaek2EqF0AP0eBjgzaalPXSNvCEN6ZYHvUzdA50ENDVeSYFXcUsYf3+FsD3XKaeptA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-x64-msvc/-/solidity-analyzer-win32-x64-msvc-0.1.1.tgz",
+      "integrity": "sha512-HrVJr6+WjIXGnw3Q9u6KQcbZCtk0caVWhCdFADySvRyUxJ8PnzlaP+MhwNE8oyT8OZ6ejHBRrrgjSqDCFXGirw==",
       "optional": true,
       "peer": true
     },
@@ -36385,29 +36464,29 @@
       }
     },
     "@scure/base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
-      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
+      "integrity": "sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ==",
       "peer": true
     },
     "@scure/bip32": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.0.tgz",
-      "integrity": "sha512-ftTW3kKX54YXLCxH6BB7oEEoJfoE2pIgw7MINKAs5PsS6nqKPuKk1haTF/EuHmYqG330t5GSrdmtRuHaY1a62Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz",
+      "integrity": "sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==",
       "peer": true,
       "requires": {
-        "@noble/hashes": "~1.1.1",
-        "@noble/secp256k1": "~1.6.0",
+        "@noble/hashes": "~1.2.0",
+        "@noble/secp256k1": "~1.7.0",
         "@scure/base": "~1.1.0"
       }
     },
     "@scure/bip39": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.0.tgz",
-      "integrity": "sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz",
+      "integrity": "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==",
       "peer": true,
       "requires": {
-        "@noble/hashes": "~1.1.1",
+        "@noble/hashes": "~1.2.0",
         "@scure/base": "~1.1.0"
       }
     },
@@ -38406,12 +38485,6 @@
         "ethers": "^5.0.2"
       }
     },
-    "@types/async-eventemitter": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@types/async-eventemitter/-/async-eventemitter-0.2.1.tgz",
-      "integrity": "sha512-M2P4Ng26QbAeITiH7w1d7OxtldgfAe0wobpyJzVK/XOb0cUGKU2R4pfAhqcJBXAe2ife5ZOhSv4wk7p+ffURtg==",
-      "peer": true
-    },
     "@types/bignumber.js": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-5.0.0.tgz",
@@ -38500,19 +38573,19 @@
       "integrity": "sha512-koZJ89uLZufDvToeWO5BrC4CR4OUfHnUz2qoPs/daQH6qq3IN62QFxCTZ+bKaCE0xaoCAJYE4AXre8AbghCrhg=="
     },
     "@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
       "peer": true,
       "requires": {
         "@types/node": "*",
-        "form-data": "^3.0.0"
+        "form-data": "^4.0.0"
       },
       "dependencies": {
         "form-data": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
           "peer": true,
           "requires": {
             "asynckit": "^0.4.0",
@@ -38531,10 +38604,20 @@
       }
     },
     "@types/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
       "peer": true
+    },
+    "@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "peer": true,
+      "requires": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
     },
     "@types/resolve": {
       "version": "0.0.8",
@@ -38608,15 +38691,6 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
       "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
       "dev": true
-    },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "peer": true,
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
     },
     "abortcontroller-polyfill": {
       "version": "1.7.5",
@@ -38932,17 +39006,9 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.14"
-      }
-    },
-    "async-eventemitter": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
-      "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
-      "peer": true,
-      "requires": {
-        "async": "^2.4.0"
       }
     },
     "async-limiter": {
@@ -38954,6 +39020,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "peer": true
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -39691,18 +39763,9 @@
       "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ=="
     },
     "bigint-crypto-utils": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.1.7.tgz",
-      "integrity": "sha512-zpCQpIE2Oy5WIQpjC9iYZf8Uh9QqoS51ZCooAcNvzv1AQ3VWdT52D0ksr1+/faeK8HVIej1bxXcP75YcqH3KPA==",
-      "peer": true,
-      "requires": {
-        "bigint-mod-arith": "^3.1.0"
-      }
-    },
-    "bigint-mod-arith": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bigint-mod-arith/-/bigint-mod-arith-3.1.2.tgz",
-      "integrity": "sha512-nx8J8bBeiRR+NlsROFH9jHswW5HO8mgfOSqW0AmjicMMvaONDa8AO+5ViKDUUNytBPWiwfvZP4/Bj4Y3lUfvgQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.3.0.tgz",
+      "integrity": "sha512-jOTSb+drvEDxEq6OuUybOAv/xxoh3cuYRUIPyu8sSHQNKM303UQ2R1DAo45o1AkcIXw6fzbaFI1+xGGdaXs2lg==",
       "peer": true
     },
     "bignumber.js": {
@@ -40093,6 +40156,12 @@
       "integrity": "sha512-ic/jXfa6tgiPBAISWk16jRI2q8YfjxHnSG7ddSL1ptrIP8Uy11SayFrjXRAk3NumHpDb21fdTkbTxb/hOrFrnQ==",
       "dev": true
     },
+    "case": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/case/-/case-1.6.3.tgz",
+      "integrity": "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==",
+      "peer": true
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -40287,15 +40356,15 @@
       "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
     },
     "classic-level": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
-      "integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.3.0.tgz",
+      "integrity": "sha512-iwFAJQYtqRTRM0F6L8h4JCt00ZSGdOyqh7yVrhhjrOpFhmBjNlRUey64MCiyo6UmQHMJ+No3c81nujPv+n9yrg==",
       "peer": true,
       "requires": {
         "abstract-level": "^1.0.2",
         "catering": "^2.1.0",
         "module-error": "^1.0.1",
-        "napi-macros": "~2.0.0",
+        "napi-macros": "^2.2.2",
         "node-gyp-build": "^4.3.0"
       }
     },
@@ -41167,12 +41236,13 @@
       }
     },
     "enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "peer": true,
       "requires": {
-        "ansi-colors": "^4.1.1"
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
       },
       "dependencies": {
         "ansi-colors": {
@@ -41180,6 +41250,21 @@
           "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
           "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
           "peer": true
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "peer": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "peer": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
         }
       }
     },
@@ -41819,7 +41904,8 @@
     "ethereumjs-common": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
-      "integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA=="
+      "integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA==",
+      "dev": true
     },
     "ethereumjs-testrpc-sc": {
       "version": "6.5.1-sc.1",
@@ -41832,12 +41918,6 @@
         "yargs": "13.2.4"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "extraneous": true
-        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -41976,12 +42056,6 @@
               }
             }
           }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "extraneous": true
         },
         "color-convert": {
           "version": "1.9.3",
@@ -42365,12 +42439,6 @@
             "path-key": "^2.0.0"
           }
         },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "extraneous": true
-        },
         "once": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -42586,35 +42654,6 @@
             "source-map": "^0.6.0"
           }
         },
-        "string-width": {
-          "version": "1.0.2",
-          "extraneous": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          },
-          "dependencies": {
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "extraneous": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "extraneous": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
         "strip-eof": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -42754,6 +42793,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
       "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
+      "dev": true,
       "requires": {
         "ethereumjs-common": "^1.5.0",
         "ethereumjs-util": "^6.0.0"
@@ -42855,12 +42895,6 @@
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
       }
-    },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "peer": true
     },
     "eventemitter3": {
       "version": "4.0.7",
@@ -51239,28 +51273,27 @@
       }
     },
     "hardhat": {
-      "version": "2.12.4",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.12.4.tgz",
-      "integrity": "sha512-rc9S2U/4M+77LxW1Kg7oqMMmjl81tzn5rNFARhbXKUA1am/nhfMJEujOjuKvt+ZGMiZ11PYSe8gyIpB/aRNDgw==",
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.19.3.tgz",
+      "integrity": "sha512-zUvfILiu1O7W1a+t5E1nCJ6z1danRLNizQkSEQCCgDYcRx13AGXtH1MVZajKmdLmXIjKAPReTp/8JQQ4ZHaX3g==",
       "peer": true,
       "requires": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@nomicfoundation/ethereumjs-vm": "^6.0.0",
+        "@nomicfoundation/ethereumjs-block": "5.0.2",
+        "@nomicfoundation/ethereumjs-blockchain": "7.0.2",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-evm": "2.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-statemanager": "2.0.2",
+        "@nomicfoundation/ethereumjs-trie": "6.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
+        "@nomicfoundation/ethereumjs-vm": "7.0.2",
         "@nomicfoundation/solidity-analyzer": "^0.1.0",
         "@sentry/node": "^5.18.1",
         "@types/bn.js": "^5.1.0",
         "@types/lru-cache": "^5.1.0",
-        "abort-controller": "^3.0.0",
         "adm-zip": "^0.4.16",
         "aggregate-error": "^3.0.0",
         "ansi-escapes": "^4.3.0",
@@ -51283,7 +51316,6 @@
         "mnemonist": "^0.38.0",
         "mocha": "^10.0.0",
         "p-map": "^4.0.0",
-        "qs": "^6.7.0",
         "raw-body": "^2.4.1",
         "resolve": "1.17.0",
         "semver": "^6.3.0",
@@ -51291,7 +51323,7 @@
         "source-map-support": "^0.5.13",
         "stacktrace-parser": "^0.1.10",
         "tsort": "0.0.1",
-        "undici": "^5.4.0",
+        "undici": "^5.14.0",
         "uuid": "^8.3.2",
         "ws": "^7.4.6"
       },
@@ -51314,9 +51346,9 @@
           }
         },
         "@types/bn.js": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
-          "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.5.tgz",
+          "integrity": "sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==",
           "peer": true,
           "requires": {
             "@types/node": "*"
@@ -51370,15 +51402,15 @@
           "peer": true
         },
         "ethereum-cryptography": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz",
-          "integrity": "sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
+          "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
           "peer": true,
           "requires": {
-            "@noble/hashes": "1.1.2",
-            "@noble/secp256k1": "1.6.3",
-            "@scure/bip32": "1.1.0",
-            "@scure/bip39": "1.1.0"
+            "@noble/hashes": "1.2.0",
+            "@noble/secp256k1": "1.7.1",
+            "@scure/bip32": "1.1.5",
+            "@scure/bip39": "1.1.1"
           }
         },
         "http-errors": {
@@ -51410,9 +51442,9 @@
           }
         },
         "keccak": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
-          "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
+          "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
           "peer": true,
           "requires": {
             "node-addon-api": "^2.0.0",
@@ -51427,9 +51459,9 @@
           "peer": true
         },
         "raw-body": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-          "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+          "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
           "peer": true,
           "requires": {
             "bytes": "3.1.2",
@@ -51439,9 +51471,9 @@
           }
         },
         "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
           "peer": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -51465,9 +51497,9 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "peer": true
         },
         "setprototypeof": {
@@ -51507,9 +51539,9 @@
               }
             },
             "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "version": "5.7.2",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+              "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
               "peer": true
             }
           }
@@ -51915,9 +51947,9 @@
       "dev": true
     },
     "immutable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
+      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
       "peer": true
     },
     "import-fresh": {
@@ -52384,6 +52416,12 @@
         "is-object": "^1.0.1"
       }
     },
+    "js-sdsl": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.2.tgz",
+      "integrity": "sha512-dwXFwByc/ajSV6m5bcKAPwe4yDDF6D614pxmIi5odytzxRlwqF6nwoiCek80Ixc7Cvma5awClxrzFtxCQvcM8w==",
+      "peer": true
+    },
     "js-sha3": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
@@ -52822,6 +52860,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -53262,9 +53301,9 @@
       "peer": true
     },
     "napi-macros": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
-      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
+      "integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
       "peer": true
     },
     "natural-compare": {
@@ -55174,8 +55213,7 @@
     "object-inspect": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-      "dev": true
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -55490,16 +55528,16 @@
       }
     },
     "patch-package": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.0.tgz",
-      "integrity": "sha512-tC3EqJmo74yKqfsMzELaFwxOAu6FH6t+FzFOsnWAuARm7/n2xB5AOeOueE221eM9gtMuIKMKpF9tBy/X2mNP0Q==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.1.tgz",
+      "integrity": "sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==",
       "peer": true,
       "requires": {
         "@yarnpkg/lockfile": "^1.1.0",
         "chalk": "^4.1.2",
         "cross-spawn": "^6.0.5",
         "find-yarn-workspace-root": "^2.0.0",
-        "fs-extra": "^7.0.1",
+        "fs-extra": "^9.0.0",
         "is-ci": "^2.0.0",
         "klaw-sync": "^6.0.0",
         "minimist": "^1.2.6",
@@ -55545,11 +55583,33 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "peer": true
         },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "peer": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "peer": true
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "peer": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
         },
         "slash": {
           "version": "2.0.0",
@@ -55565,6 +55625,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "universalify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+          "peer": true
         }
       }
     },
@@ -55750,7 +55816,8 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "psl": {
       "version": "1.8.0",
@@ -55809,12 +55876,6 @@
         "object-assign": "^4.1.0",
         "strict-uri-encode": "^1.0.0"
       }
-    },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "peer": true
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -56447,7 +56508,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -57210,12 +57270,14 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
     },
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
       "requires": {
         "source-map": "^0.5.6"
       }
@@ -57951,9 +58013,9 @@
           }
         },
         "prettier": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
-          "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+          "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
           "peer": true
         },
         "supports-color": {
@@ -58107,9 +58169,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "peer": true
     },
     "typical": {
@@ -58196,20 +58258,29 @@
       }
     },
     "url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
+      "integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
       "peer": true,
       "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
+        "punycode": "^1.4.1",
+        "qs": "^6.11.2"
       },
       "dependencies": {
         "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
           "peer": true
+        },
+        "qs": {
+          "version": "6.11.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+          "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+          "peer": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
         }
       }
     },
@@ -59068,6 +59139,7 @@
     },
     "websocket": {
       "version": "git+ssh://git@github.com/web3-js/WebSocket-Node.git#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
+      "integrity": "sha512-fS64f2anyRmFjuEVoqTbtgtV4Ay1dQ6kP078yM1RxnF0+9hNYk4iirrtII6FIoNoNgmhhIqzQaadEU6ZRpGoEw==",
       "from": "websocket@github:web3-js/WebSocket-Node#polyfill/globalThis",
       "requires": {
         "debug": "^2.2.0",
@@ -59295,7 +59367,8 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opera-sfc",
-  "version": "3.0.4-rc.7",
+  "version": "3.0.4-rc.8",
   "description": "Special Fee Contract",
   "scripts": {
     "lint:js": "eslint \"test/*.js\"",


### PR DESCRIPTION
This pull request (PR) introduces significant changes to the lockup penalty system. Previously, relocking resulted in an accumulating penalty across all lockup periods. With this update, the system now maintains a record of each individual relocked lockup, calculating penalties solely for those lockup periods that have not yet expired. Consequently, there is a new limit in place, restricting users to a maximum of 30 ongoing relocked lockup periods.

To safeguard users against inadvertently exceeding this limit, relocking now has specific prerequisites. It can only be initiated under at least one of the following conditions:
- A minimum of 14 days has elapsed since the last relock.
- The relock results in an increase of the lockup amount by at least 1%.
- The total number of active relocks does not exceed 3.

Furthermore, to reduce the frequency at which validators need to relock, the requirements for a delegator's lockup have been modified. Previously, a delegator could not extend their lockup period beyond that of the validator's. Now, delegators are permitted to lockup for up to an additional 30 days beyond the validator's lockup period.

This PR also implements a heuristic which decreases excessive lockup penalty for already existing relocked positions.

This proposal serves as a continuation and expansion of the initiatives laid out in PR #66.