### PR TITLE
Add average uptime for validators

### DIFF
--- a/contracts/sfc/ConstantsManager.sol
+++ b/contracts/sfc/ConstantsManager.sol
@@ -33,7 +33,7 @@ contract ConstantsManager is Ownable {
     uint256 public gasPriceBalancingCounterweight;
 
     // epoch threshold for stop counting alive epochs (avoid diminishing impact of new uptimes) and
-    // is also the minimum number of epochs necessary for enabling the deactivation. 
+    // is also the minimum number of epochs necessary for enabling the deactivation.
     int32 public numEpochsAliveThreshold;
 
     // minimum average uptime in Q1.30 format; acceptable bounds [0,0.9]
@@ -208,7 +208,8 @@ contract ConstantsManager is Ownable {
         if (v < 0) {
             revert ValueTooSmall();
         }
-        if (v > 966367641) { // 0.9 in Q1.30
+        if (v > 966367641) {
+            // 0.9 in Q1.30
             revert ValueTooLarge();
         }
         minAverageUptime = v;

--- a/contracts/sfc/ConstantsManager.sol
+++ b/contracts/sfc/ConstantsManager.sol
@@ -32,6 +32,9 @@ contract ConstantsManager is Ownable {
     uint256 public targetGasPowerPerSecond;
     uint256 public gasPriceBalancingCounterweight;
 
+    // number of epochs for counting the average uptime of validators
+    int32 public numEpochsAliveThreshold;
+
     /**
      * @dev Given value is too small
      */
@@ -185,5 +188,15 @@ contract ConstantsManager is Ownable {
             revert ValueTooLarge();
         }
         gasPriceBalancingCounterweight = v;
+    }
+
+    function updateNumEpochsAliveThreshold(int32 v) external virtual onlyOwner {
+        if (v < 10) {
+            revert ValueTooSmall();
+        }
+        if (v > 87600) {
+            revert ValueTooLarge();
+        }
+        numEpochsAliveThreshold = v;
     }
 }

--- a/contracts/sfc/ConstantsManager.sol
+++ b/contracts/sfc/ConstantsManager.sol
@@ -35,6 +35,9 @@ contract ConstantsManager is Ownable {
     // number of epochs for counting the average uptime of validators
     int32 public numEpochsAliveThreshold;
 
+    // minimum average uptime
+    int32 public minAverageUptime;
+
     /**
      * @dev Given value is too small
      */
@@ -198,5 +201,15 @@ contract ConstantsManager is Ownable {
             revert ValueTooLarge();
         }
         numEpochsAliveThreshold = v;
+    }
+
+    function updateMinAverageUptime(int32 v) external virtual onlyOwner {
+        if (v < 0) {
+            revert ValueTooSmall();
+        }
+        if (v > 966367641) { // 0.9 in Q1.30
+            revert ValueTooLarge();
+        }
+        minAverageUptime = v;
     }
 }

--- a/contracts/sfc/ConstantsManager.sol
+++ b/contracts/sfc/ConstantsManager.sol
@@ -32,10 +32,11 @@ contract ConstantsManager is Ownable {
     uint256 public targetGasPowerPerSecond;
     uint256 public gasPriceBalancingCounterweight;
 
-    // number of epochs for counting the average uptime of validators
+    // epoch threshold for stop counting alive epochs (avoid diminishing impact of new uptimes) and
+    // is also the minimum number of epochs necessary for enabling the deactivation. 
     int32 public numEpochsAliveThreshold;
 
-    // minimum average uptime
+    // minimum average uptime in Q1.30 format; acceptable bounds [0,0.9]
     int32 public minAverageUptime;
 
     /**

--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -382,21 +382,24 @@ contract SFC is SFCBase, Version {
         for (uint256 i = 0; i < validatorIDs.length; i++) {
             uint256 validatorID = validatorIDs[i];
             // compute normalised uptime as a percentage in the Q1.30 fixed-point format
-            uint256 normalisedUptime = uptimes[i] * (1 << 30)/ epochDuration;
+            uint256 normalisedUptime = (uptimes[i] * (1 << 30)) / epochDuration;
             if (normalisedUptime < 0) {
                 normalisedUptime = 0;
             } else if (normalisedUptime > 1 << 30) {
                 normalisedUptime = 1 << 30;
             }
-            // update average uptime data structure 
+            // update average uptime data structure
             // Assumes that if in the previous snapshot the validator
             // does not exist, the map returns zero.
             int32 n = prevSnapshot.averageData[validatorID].numEpochsAlive;
             int64 tmp;
-            if (n > 0) { 
-                tmp = int64(n-1) * int64(snapshot.averageData[validatorID].averageUptime) + int64(uint64(normalisedUptime));
-                if (n > 1)  {
-                    tmp += (int64(n) * int64(prevSnapshot.averageData[validatorID].averageUptimeError)) / int64(n-1);
+            if (n > 0) {
+                tmp =
+                    int64(n - 1) *
+                    int64(snapshot.averageData[validatorID].averageUptime) +
+                    int64(uint64(normalisedUptime));
+                if (n > 1) {
+                    tmp += (int64(n) * int64(prevSnapshot.averageData[validatorID].averageUptimeError)) / int64(n - 1);
                 }
                 snapshot.averageData[validatorID].averageUptimeError = int32(tmp % int64(n));
                 tmp /= int64(n);
@@ -404,9 +407,9 @@ contract SFC is SFCBase, Version {
                 tmp = int64(uint64(normalisedUptime));
             }
             if (tmp < 0) {
-               tmp = 0;
-            } else if (tmp > 1 << 30){
-               tmp = 1 << 30;
+                tmp = 0;
+            } else if (tmp > 1 << 30) {
+                tmp = 1 << 30;
             }
             snapshot.averageData[validatorID].averageUptime = int32(tmp);
             if (n < c.numEpochsAliveThreshold()) {
@@ -414,7 +417,7 @@ contract SFC is SFCBase, Version {
             }
             // remove validator if average uptime drops below min average uptime
             // (by setting minAverageUptime to zero, this check is ignored)
-            if (int32(tmp) < c.minAverageUptime() && n >= c.numEpochsAliveThreshold() ) { 
+            if (int32(tmp) < c.minAverageUptime() && n >= c.numEpochsAliveThreshold()) {
                 _setValidatorDeactivated(validatorIDs[i], OFFLINE_BIT);
                 _syncValidator(validatorIDs[i], false);
             }

--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -70,6 +70,10 @@ contract SFC is SFCBase, Version {
         return getEpochSnapshot[epoch].accumulatedUptime[validatorID];
     }
 
+    function getEpochAverageUptime(uint256 epoch, uint256 validatorID) public view returns (int32) {
+        return getEpochSnapshot[epoch].averageUptime[validatorID];
+    }
+
     function getEpochAccumulatedOriginatedTxsFee(uint256 epoch, uint256 validatorID) public view returns (uint256) {
         return getEpochSnapshot[epoch].accumulatedOriginatedTxsFee[validatorID];
     }

--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -71,7 +71,7 @@ contract SFC is SFCBase, Version {
     }
 
     function getEpochAverageUptime(uint256 epoch, uint256 validatorID) public view returns (int32) {
-        return getEpochSnapshot[epoch].averageUptime[validatorID];
+        return getEpochSnapshot[epoch].averageData[validatorID].averageUptime;
     }
 
     function getEpochAccumulatedOriginatedTxsFee(uint256 epoch, uint256 validatorID) public view returns (uint256) {
@@ -389,14 +389,14 @@ contract SFC is SFCBase, Version {
             }
             // Assumes that if in the previous snapshot the validator
             // does not exist, the map returns zero.
-            int32 n = prevSnapshot.numEpochsAlive[validatorID];
+            int32 n = prevSnapshot.averageData[validatorID].numEpochsAlive;
             int64 tmp;
             if (n > 0) { 
-                tmp = int64(n-1) * int64(snapshot.averageUptime[validatorID]) + int64(uint64(normalisedUptime));
+                tmp = int64(n-1) * int64(snapshot.averageData[validatorID].averageUptime) + int64(uint64(normalisedUptime));
                 if (n > 1)  {
-                    tmp += (int64(n) * int64(prevSnapshot.averageUptimeError[validatorID])) / int64(n-1);
+                    tmp += (int64(n) * int64(prevSnapshot.averageData[validatorID].averageUptimeError)) / int64(n-1);
                 }
-                snapshot.averageUptimeError[validatorID] = int32(tmp % int64(n));
+                snapshot.averageData[validatorID].averageUptimeError = int32(tmp % int64(n));
                 tmp /= int64(n);
             } else {
                 tmp = int64(uint64(normalisedUptime));
@@ -406,9 +406,9 @@ contract SFC is SFCBase, Version {
             } else if (tmp > 1 << 30){
                tmp = 1 << 30;
             }
-            snapshot.averageUptime[validatorID] = int32(tmp);
+            snapshot.averageData[validatorID].averageUptime = int32(tmp);
             if (n < c.numEpochsAliveThreshold()) {
-                snapshot.numEpochsAlive[validatorID] = n + 1;
+                snapshot.averageData[validatorID].numEpochsAlive = n + 1;
             }
         }
     }

--- a/contracts/sfc/SFCState.sol
+++ b/contracts/sfc/SFCState.sol
@@ -48,8 +48,8 @@ contract SFCState is Initializable, Ownable {
     mapping(address => mapping(uint256 => uint256)) public stashedRewardsUntilEpoch;
 
     struct WithdrawalRequest {
-        uint256 epoch;  // epoch where undelegated
-        uint256 time;   // when undelegated
+        uint256 epoch; // epoch where undelegated
+        uint256 time; // when undelegated
         uint256 amount;
     }
 
@@ -73,12 +73,12 @@ contract SFCState is Initializable, Ownable {
 
     // data structure to compute average uptime for each active validator
     struct AverageData {
-        // average uptime 
+        // average uptime
         int32 averageUptime;
         // average uptime error term
         int32 averageUptimeError;
         // number of alive epochs (counts only up to numEpochsAliveThreshold)
-        int32 numEpochsAlive; 
+        int32 numEpochsAlive;
     }
 
     struct EpochSnapshot {
@@ -88,7 +88,7 @@ contract SFCState is Initializable, Ownable {
         mapping(uint256 => uint256) accumulatedRewardPerToken;
         // validator ID => accumulated online time
         mapping(uint256 => uint256) accumulatedUptime;
-        // validator ID => average uptime as a percentage 
+        // validator ID => average uptime as a percentage
         mapping(uint256 => AverageData) averageData;
         // validator ID => gas fees from txs originated by the validator
         mapping(uint256 => uint256) accumulatedOriginatedTxsFee;

--- a/contracts/sfc/SFCState.sol
+++ b/contracts/sfc/SFCState.sol
@@ -48,8 +48,8 @@ contract SFCState is Initializable, Ownable {
     mapping(address => mapping(uint256 => uint256)) public stashedRewardsUntilEpoch;
 
     struct WithdrawalRequest {
-        uint256 epoch; // epoch where undelegated
-        uint256 time; // when undelegated
+        uint256 epoch;  // epoch where undelegated
+        uint256 time;   // when undelegated
         uint256 amount;
     }
 
@@ -71,6 +71,16 @@ contract SFCState is Initializable, Ownable {
 
     mapping(address => mapping(uint256 => Rewards)) public getStashedLockupRewards;
 
+    // data structure to compute average uptime for each active validator
+    struct AverageData {
+        // average uptime 
+        int32 averageUptime;
+        // average uptime error term
+        int32 averageUptimeError;
+        // number of alive epochs (counts only up to numEpochsAliveThreshold)
+        int32 numEpochsAlive; 
+    }
+
     struct EpochSnapshot {
         // validator ID => validator weight in the epoch
         mapping(uint256 => uint256) receivedStake;
@@ -79,11 +89,7 @@ contract SFCState is Initializable, Ownable {
         // validator ID => accumulated online time
         mapping(uint256 => uint256) accumulatedUptime;
         // validator ID => average uptime as a percentage 
-        mapping(uint256 => int32) averageUptime;
-        // validator ID => error term of average uptime
-        mapping(uint256 => int32) averageUptimeError;
-        // validator ID => number of epochs alive for average uptime calculation
-        mapping(uint256 => int32) numEpochsAlive;
+        mapping(uint256 => AverageData) averageData;
         // validator ID => gas fees from txs originated by the validator
         mapping(uint256 => uint256) accumulatedOriginatedTxsFee;
         mapping(uint256 => uint256) offlineTime;

--- a/contracts/sfc/SFCState.sol
+++ b/contracts/sfc/SFCState.sol
@@ -78,6 +78,12 @@ contract SFCState is Initializable, Ownable {
         mapping(uint256 => uint256) accumulatedRewardPerToken;
         // validator ID => accumulated online time
         mapping(uint256 => uint256) accumulatedUptime;
+        // validator ID => average uptime as a percentage 
+        mapping(uint256 => int32) averageUptime;
+        // validator ID => error term of average uptime
+        mapping(uint256 => int32) averageUptimeError;
+        // validator ID => number of epochs alive for average uptime calculation
+        mapping(uint256 => int32) numEpochsAlive;
         // validator ID => gas fees from txs originated by the validator
         mapping(uint256 => uint256) accumulatedOriginatedTxsFee;
         mapping(uint256 => uint256) offlineTime;


### PR DESCRIPTION
This PR adds a state to the SFC so that the SFC can track the average uptime of several epochs. The average uptime is computed efficiently and represented as a fixed-point number in the format Q1.30, representing a number between [0,1].
