### PR TITLE
Add average uptime calculation

### DIFF
--- a/contracts/interfaces/ISFC.sol
+++ b/contracts/interfaces/ISFC.sol
@@ -111,6 +111,8 @@ interface ISFC {
 
     function getEpochAccumulatedUptime(uint256 epoch, uint256 validatorID) external view returns (uint256);
 
+    function getEpochAverageUptime(uint256 epoch, uint256 validatorID) external view returns (uint32);
+
     function getEpochAccumulatedOriginatedTxsFee(uint256 epoch, uint256 validatorID) external view returns (uint256);
 
     function getEpochOfflineTime(uint256 epoch, uint256 validatorID) external view returns (uint256);

--- a/contracts/sfc/ConstantsManager.sol
+++ b/contracts/sfc/ConstantsManager.sol
@@ -29,13 +29,13 @@ contract ConstantsManager is Ownable {
     uint256 public targetGasPowerPerSecond;
     uint256 public gasPriceBalancingCounterweight;
 
-    // Epoch threshold for stop counting alive epochs (avoid diminishing impact of new uptimes).
+    // The number of epochs to calculate the average uptime ratio from, acceptable bound [10, 87600].
     // Is also the minimum number of epochs necessary for deactivation of offline validators.
-    uint32 public averageUptimeEpochsThreshold;
+    uint32 public averageUptimeEpochWindow;
 
-    // Minimum average uptime in Q1.30 format; acceptable bounds [0,0.9]
+    // Minimum average uptime ratio in fixed-point format; acceptable bounds [0,0.9].
     // Zero to disable validators deactivation by this metric.
-    uint32 public minAverageUptime;
+    uint64 public minAverageUptime;
 
     /**
      * @dev Given value is too small
@@ -162,19 +162,19 @@ contract ConstantsManager is Ownable {
         gasPriceBalancingCounterweight = v;
     }
 
-    function updateAverageUptimeEpochsThreshold(uint32 v) external virtual onlyOwner {
+    function updateAverageUptimeEpochWindow(uint32 v) external virtual onlyOwner {
         if (v < 10) {
+            // needs to be long enough to allow permissible downtime for validators maintenance
             revert ValueTooSmall();
         }
         if (v > 87600) {
             revert ValueTooLarge();
         }
-        averageUptimeEpochsThreshold = v;
+        averageUptimeEpochWindow = v;
     }
 
-    function updateMinAverageUptime(uint32 v) external virtual onlyOwner {
-        if (v > 966367641) {
-            // 0.9 in Q1.30
+    function updateMinAverageUptime(uint64 v) external virtual onlyOwner {
+        if (v > ((Decimal.unit() * 9) / 10)) {
             revert ValueTooLarge();
         }
         minAverageUptime = v;

--- a/contracts/sfc/ConstantsManager.sol
+++ b/contracts/sfc/ConstantsManager.sol
@@ -29,6 +29,12 @@ contract ConstantsManager is Ownable {
     uint256 public targetGasPowerPerSecond;
     uint256 public gasPriceBalancingCounterweight;
 
+    // the number of epochs for counting the average uptime of validators
+    int32 public averageUptimeEpochsWindow;
+
+    // minimum average uptime
+    int32 public minAverageUptime;
+
     /**
      * @dev Given value is too small
      */
@@ -152,5 +158,26 @@ contract ConstantsManager is Ownable {
             revert ValueTooLarge();
         }
         gasPriceBalancingCounterweight = v;
+    }
+
+    function updateAverageUptimeEpochsWindow(int32 v) external virtual onlyOwner {
+        if (v < 10) {
+            revert ValueTooSmall();
+        }
+        if (v > 87600) {
+            revert ValueTooLarge();
+        }
+        averageUptimeEpochsWindow = v;
+    }
+
+    function updateMinAverageUptime(int32 v) external virtual onlyOwner {
+        if (v < 0) {
+            revert ValueTooSmall();
+        }
+        if (v > 966367641) {
+            // 0.9 in Q1.30
+            revert ValueTooLarge();
+        }
+        minAverageUptime = v;
     }
 }

--- a/contracts/sfc/ConstantsManager.sol
+++ b/contracts/sfc/ConstantsManager.sol
@@ -30,10 +30,10 @@ contract ConstantsManager is Ownable {
     uint256 public gasPriceBalancingCounterweight;
 
     // the number of epochs for counting the average uptime of validators
-    int32 public averageUptimeEpochsWindow;
+    uint32 public averageUptimeEpochsWindow;
 
     // minimum average uptime
-    int32 public minAverageUptime;
+    uint32 public minAverageUptime;
 
     /**
      * @dev Given value is too small
@@ -160,7 +160,7 @@ contract ConstantsManager is Ownable {
         gasPriceBalancingCounterweight = v;
     }
 
-    function updateAverageUptimeEpochsWindow(int32 v) external virtual onlyOwner {
+    function updateAverageUptimeEpochsWindow(uint32 v) external virtual onlyOwner {
         if (v < 10) {
             revert ValueTooSmall();
         }
@@ -170,10 +170,7 @@ contract ConstantsManager is Ownable {
         averageUptimeEpochsWindow = v;
     }
 
-    function updateMinAverageUptime(int32 v) external virtual onlyOwner {
-        if (v < 0) {
-            revert ValueTooSmall();
-        }
+    function updateMinAverageUptime(uint32 v) external virtual onlyOwner {
         if (v > 966367641) {
             // 0.9 in Q1.30
             revert ValueTooLarge();

--- a/contracts/sfc/ConstantsManager.sol
+++ b/contracts/sfc/ConstantsManager.sol
@@ -29,10 +29,12 @@ contract ConstantsManager is Ownable {
     uint256 public targetGasPowerPerSecond;
     uint256 public gasPriceBalancingCounterweight;
 
-    // the number of epochs for counting the average uptime of validators
-    uint32 public averageUptimeEpochsWindow;
+    // Epoch threshold for stop counting alive epochs (avoid diminishing impact of new uptimes).
+    // Is also the minimum number of epochs necessary for deactivation of offline validators.
+    uint32 public averageUptimeEpochsThreshold;
 
-    // minimum average uptime
+    // Minimum average uptime in Q1.30 format; acceptable bounds [0,0.9]
+    // Zero to disable validators deactivation by this metric.
     uint32 public minAverageUptime;
 
     /**
@@ -160,14 +162,14 @@ contract ConstantsManager is Ownable {
         gasPriceBalancingCounterweight = v;
     }
 
-    function updateAverageUptimeEpochsWindow(uint32 v) external virtual onlyOwner {
+    function updateAverageUptimeEpochsThreshold(uint32 v) external virtual onlyOwner {
         if (v < 10) {
             revert ValueTooSmall();
         }
         if (v > 87600) {
             revert ValueTooLarge();
         }
-        averageUptimeEpochsWindow = v;
+        averageUptimeEpochsThreshold = v;
     }
 
     function updateMinAverageUptime(uint32 v) external virtual onlyOwner {

--- a/contracts/sfc/NetworkInitializer.sol
+++ b/contracts/sfc/NetworkInitializer.sol
@@ -37,7 +37,7 @@ contract NetworkInitializer {
         consts.updateOfflinePenaltyThresholdBlocksNum(1000);
         consts.updateTargetGasPowerPerSecond(2000000);
         consts.updateGasPriceBalancingCounterweight(3600);
-        consts.updateAverageUptimeEpochsThreshold(100);
+        consts.updateAverageUptimeEpochWindow(100);
         consts.updateMinAverageUptime(0); // check disabled by default
         consts.transferOwnership(_owner);
 

--- a/contracts/sfc/NetworkInitializer.sol
+++ b/contracts/sfc/NetworkInitializer.sol
@@ -37,8 +37,8 @@ contract NetworkInitializer {
         consts.updateOfflinePenaltyThresholdBlocksNum(1000);
         consts.updateTargetGasPowerPerSecond(2000000);
         consts.updateGasPriceBalancingCounterweight(3600);
-        consts.updateAverageUptimeEpochsWindow(20);
-        consts.updateMinAverageUptime(0);
+        consts.updateAverageUptimeEpochsThreshold(100);
+        consts.updateMinAverageUptime(0); // check disabled by default
         consts.transferOwnership(_owner);
 
         ISFC(_sfc).initialize(sealedEpoch, totalSupply, _auth, address(consts), _owner);

--- a/contracts/sfc/NetworkInitializer.sol
+++ b/contracts/sfc/NetworkInitializer.sol
@@ -37,6 +37,8 @@ contract NetworkInitializer {
         consts.updateOfflinePenaltyThresholdBlocksNum(1000);
         consts.updateTargetGasPowerPerSecond(2000000);
         consts.updateGasPriceBalancingCounterweight(3600);
+        consts.updateAverageUptimeEpochsWindow(20);
+        consts.updateMinAverageUptime(0);
         consts.transferOwnership(_owner);
 
         ISFC(_sfc).initialize(sealedEpoch, totalSupply, _auth, address(consts), _owner);

--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -68,6 +68,16 @@ contract SFC is Initializable, Ownable, Version {
     // delegator => validator ID => current stake
     mapping(address delegator => mapping(uint256 validatorID => uint256 stake)) public getStake;
 
+    // data structure to compute average uptime for each active validator
+    struct AverageData {
+        // average uptime
+        int32 averageUptime;
+        // average uptime error term
+        int32 averageUptimeError;
+        // number of alive epochs (counts only up to averageUptimeEpochsWindow)
+        int32 numEpochsAlive;
+    }
+
     struct EpochSnapshot {
         // validator ID => validator weight in the epoch
         mapping(uint256 => uint256) receivedStake;
@@ -75,6 +85,8 @@ contract SFC is Initializable, Ownable, Version {
         mapping(uint256 => uint256) accumulatedRewardPerToken;
         // validator ID => accumulated online time
         mapping(uint256 => uint256) accumulatedUptime;
+        // validator ID => average uptime as a percentage
+        mapping(uint256 => AverageData) averageData;
         // validator ID => gas fees from txs originated by the validator
         mapping(uint256 => uint256) accumulatedOriginatedTxsFee;
         mapping(uint256 => uint256) offlineTime;
@@ -288,6 +300,7 @@ contract SFC is Initializable, Ownable, Version {
                 epochDuration = _now() - prevSnapshot.endTime;
             }
             _sealEpochRewards(epochDuration, snapshot, prevSnapshot, validatorIDs, uptimes, originatedTxsFee);
+            _sealEpochAverageUptime(epochDuration, snapshot, prevSnapshot, validatorIDs, uptimes);
         }
 
         currentSealedEpoch = currentEpoch();
@@ -518,6 +531,10 @@ contract SFC is Initializable, Ownable, Version {
     /// Get accumulated uptime for a validator in a given epoch.
     function getEpochAccumulatedUptime(uint256 epoch, uint256 validatorID) public view returns (uint256) {
         return getEpochSnapshot[epoch].accumulatedUptime[validatorID];
+    }
+
+    function getEpochAverageUptime(uint256 epoch, uint256 validatorID) public view returns (int32) {
+        return getEpochSnapshot[epoch].averageData[validatorID].averageUptime;
     }
 
     /// Get accumulated originated txs fee for a validator in a given epoch.
@@ -897,6 +914,50 @@ contract SFC is Initializable, Ownable, Version {
             if (!success) {
                 // ignore treasury transfer failure
                 // the treasury failure must not endanger the epoch sealing
+            }
+        }
+    }
+
+    function _sealEpochAverageUptime(
+        uint256 epochDuration,
+        EpochSnapshot storage snapshot,
+        EpochSnapshot storage prevSnapshot,
+        uint256[] memory validatorIDs,
+        uint256[] memory uptimes
+    ) internal {
+        for (uint256 i = 0; i < validatorIDs.length; i++) {
+            uint256 validatorID = validatorIDs[i];
+            uint256 normalisedUptime = (uptimes[i] * (1 << 30)) / epochDuration;
+            if (normalisedUptime < 0) {
+                normalisedUptime = 0;
+            } else if (normalisedUptime > 1 << 30) {
+                normalisedUptime = 1 << 30;
+            }
+            // Assumes that if in the previous snapshot the validator
+            // does not exist, the map returns zero.
+            int32 n = prevSnapshot.averageData[validatorID].numEpochsAlive;
+            int64 tmp;
+            if (n > 0) {
+                tmp =
+                    int64(n - 1) *
+                    int64(snapshot.averageData[validatorID].averageUptime) +
+                    int64(uint64(normalisedUptime));
+                if (n > 1) {
+                    tmp += (int64(n) * int64(prevSnapshot.averageData[validatorID].averageUptimeError)) / int64(n - 1);
+                }
+                snapshot.averageData[validatorID].averageUptimeError = int32(tmp % int64(n));
+                tmp /= int64(n);
+            } else {
+                tmp = int64(uint64(normalisedUptime));
+            }
+            if (tmp < 0) {
+                tmp = 0;
+            } else if (tmp > 1 << 30) {
+                tmp = 1 << 30;
+            }
+            snapshot.averageData[validatorID].averageUptime = int32(tmp);
+            if (n < c.averageUptimeEpochsWindow()) {
+                snapshot.averageData[validatorID].numEpochsAlive = n + 1;
             }
         }
     }

--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -961,7 +961,7 @@ contract SFC is Initializable, Ownable, Version {
 
         // the number of elements the average is calculated from
         uint128 n = prev.epochs + 1;
-        // use lemma to add new value into the average
+        // add new value into the average
         uint128 tmp = (n - 1) * uint128(prev.averageUptime) + uint128(newValue) + prev.remainder;
 
         cur.averageUptime = uint64(tmp / n);

--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -73,6 +73,8 @@ contract SFC is Initializable, Ownable, Version {
     struct AverageUptime {
         // average uptime ratio as a value between 0 and 1e18
         uint64 averageUptime;
+        // remainder from the division in the average calculation
+        uint32 remainder;
         // number of epochs in the average (at most averageUptimeEpochsWindow)
         uint32 epochs;
     }
@@ -960,7 +962,10 @@ contract SFC is Initializable, Ownable, Version {
         // the number of elements the average is calculated from
         uint128 n = prev.epochs + 1;
         // use lemma to add new value into the average
-        cur.averageUptime = uint64(((n - 1) * uint128(prev.averageUptime) + uint128(newValue)) / n);
+        uint128 tmp = (n - 1) * uint128(prev.averageUptime) + uint128(newValue) + prev.remainder;
+
+        cur.averageUptime = uint64(tmp / n);
+        cur.remainder = uint32(tmp % n);
 
         if (cur.averageUptime > Decimal.unit()) {
             cur.averageUptime = uint64(Decimal.unit());

--- a/contracts/test/UnitTestSFC.sol
+++ b/contracts/test/UnitTestSFC.sol
@@ -75,6 +75,8 @@ contract UnitTestNetworkInitializer {
         consts.updateOfflinePenaltyThresholdBlocksNum(1000);
         consts.updateTargetGasPowerPerSecond(2000000);
         consts.updateGasPriceBalancingCounterweight(6 * 60 * 60);
+        consts.updateAverageUptimeEpochWindow(10);
+        consts.updateMinAverageUptime(0); // check disabled by default
         consts.transferOwnership(_owner);
 
         ISFC(_sfc).initialize(sealedEpoch, totalSupply, _auth, address(consts), _owner);

--- a/test/SFC.ts
+++ b/test/SFC.ts
@@ -951,4 +951,82 @@ describe('SFC', () => {
       await expect(this.sfc._syncValidator(33, false)).to.be.revertedWithCustomError(this.sfc, 'ValidatorNotExists');
     });
   });
+
+  describe('Average uptime calculation', () => {
+    const validatorsFixture = async function (this: Context) {
+      const [validator] = await ethers.getSigners();
+      const pubkey =
+        '0xc000a2941866e485442aa6b17d67d77f8a6c4580bb556894cc1618473eff1e18203d8cce50b563cf4c75e408886079b8f067069442ed52e2ac9e556baa3f8fcc525f';
+      const blockchainNode = new BlockchainNode(this.sfc);
+
+      await this.sfc.rebaseTime();
+      await this.sfc.enableNonNodeCalls();
+
+      await blockchainNode.handleTx(
+        await this.sfc.connect(validator).createValidator(pubkey, { value: ethers.parseEther('10') }),
+      );
+
+      const validatorId = await this.sfc.getValidatorID(validator);
+
+      await blockchainNode.sealEpoch(0);
+
+      return {
+        validatorId,
+        blockchainNode,
+      };
+    };
+
+    beforeEach(async function () {
+      return Object.assign(this, await loadFixture(validatorsFixture.bind(this)));
+    });
+
+    it('Should calculate uptime correctly', async function () {
+      // validator online 100% of time in the first epoch => average 100%
+      await this.blockchainNode.sealEpoch(
+        100,
+        new Map<number, ValidatorMetrics>([[this.validatorId as number, new ValidatorMetrics(0, 0, 100, 0n)]]),
+      );
+      expect(await this.sfc.getEpochAverageUptime(await this.sfc.currentSealedEpoch(), this.validatorId)).to.equal(
+        1000000000000000000n,
+      );
+
+      // validator online 20% of time in the second epoch => average 60%
+      await this.blockchainNode.sealEpoch(
+        100,
+        new Map<number, ValidatorMetrics>([[this.validatorId as number, new ValidatorMetrics(0, 0, 20, 0n)]]),
+      );
+      expect(await this.sfc.getEpochAverageUptime(await this.sfc.currentSealedEpoch(), this.validatorId)).to.equal(
+        600000000000000000n,
+      );
+
+      // validator online 30% of time in the third epoch => average 50%
+      await this.blockchainNode.sealEpoch(
+        100,
+        new Map<number, ValidatorMetrics>([[this.validatorId as number, new ValidatorMetrics(0, 0, 30, 0n)]]),
+      );
+      expect(await this.sfc.getEpochAverageUptime(await this.sfc.currentSealedEpoch(), this.validatorId)).to.equal(
+        500000000000000000n,
+      );
+
+      // fill the averaging window
+      for (let i = 0; i < 10; i++) {
+        await this.blockchainNode.sealEpoch(
+          100,
+          new Map<number, ValidatorMetrics>([[this.validatorId as number, new ValidatorMetrics(0, 0, 50, 0n)]]),
+        );
+        expect(await this.sfc.getEpochAverageUptime(await this.sfc.currentSealedEpoch(), this.validatorId)).to.equal(
+          500000000000000000n,
+        );
+      }
+
+      // (50 * 10 + 28) / 11 = 48
+      await this.blockchainNode.sealEpoch(
+        100,
+        new Map<number, ValidatorMetrics>([[this.validatorId as number, new ValidatorMetrics(0, 0, 28, 0n)]]),
+      );
+      expect(await this.sfc.getEpochAverageUptime(await this.sfc.currentSealedEpoch(), this.validatorId)).to.equal(
+        480000000000000000n,
+      );
+    });
+  });
 });


### PR DESCRIPTION
* Updated and refactored version of #83
* Use Q1.30 number representation for the normalised uptime (fits into uint32)
* Used math [lemma for the average](https://docs.google.com/document/d/1kENdl4XBtBV7Zt7VmJ9Nvaq-gsinPrCbfog_CxtFHgI/)
* Used unsigned integers only to simplify checks/verification
* Disabled too inactive validators included but disabled by default. (I would prefer to include it into the audit.)