### PR TITLE
Generalize governance to stake changes subscriber

### DIFF
--- a/contracts/interfaces/ISFC.sol
+++ b/contracts/interfaces/ISFC.sol
@@ -175,9 +175,9 @@ interface ISFC {
 
     function setGenesisDelegation(address delegator, uint256 toValidatorID, uint256 stake) external;
 
-    function updateVoteBookAddress(address v) external;
+    function updateStakeSubscriberAddress(address v) external;
 
-    function voteBookAddress() external view returns (address);
+    function stakeSubscriberAddress() external view returns (address);
 
     function setRedirectionAuthorizer(address v) external;
 

--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -162,7 +162,7 @@ contract SFC is Initializable, Ownable, Version {
     error TransferFailed();
 
     // stake changes subscriber
-    error StateSubscriberFailed();
+    error StakeSubscriberFailed();
 
     // staking
     error InsufficientSelfStake();
@@ -964,7 +964,7 @@ contract SFC is Initializable, Ownable, Version {
     }
 
     /// Notify stake subscriber about staking changes.
-    /// Used to recount votes for a delegator and a validator in governance contract.
+    /// Used to recount votes from delegators in the governance contract.
     function _notifyStakeSubscriber(address delegator, address validatorAuth, bool strict) internal {
         if (stakeSubscriberAddress != address(0)) {
             // Don't allow announceStakeChange to use up all the gas
@@ -974,7 +974,7 @@ contract SFC is Initializable, Ownable, Version {
             );
             // Don't revert if announceStakeChange failed unless strict mode enabled
             if (!success && strict) {
-                revert StateSubscriberFailed();
+                revert StakeSubscriberFailed();
             }
         }
     }


### PR DESCRIPTION
As discussed today, we may generalize votebook/governance interface to a generic stake changes subscriber.

Still not confirm if needed for the bridge, but maybe it can be considered an improvement even without it.

Removed external-callable recountVotes() instance, as it only potentially breaks the security model of the called contract. (If it is inteded to be called by user, the target contract should allow it directly.)