### PR TITLE
Use the byte3 array directly for the versioning

### DIFF
--- a/contracts/version/Version.sol
+++ b/contracts/version/Version.sol
@@ -6,10 +6,9 @@ pragma solidity 0.8.27;
  */
 contract Version {
     /**
-     * @dev Returns the address of the current owner.
+     * @dev Returns the version of the SFC contract
      */
     function version() public pure returns (bytes3) {
-        // version 3.0.5
-        return "305";
+        return 0x040000; // version 4.0.0
     }
 }

--- a/test/SFC.ts
+++ b/test/SFC.ts
@@ -127,7 +127,7 @@ describe('SFC', () => {
     });
 
     it('Should succeed and return version of the current implementation', async function () {
-      expect(await this.sfc.version()).to.equal(ethers.hexlify(ethers.toUtf8Bytes('305')));
+      expect(await this.sfc.version()).to.equal('0x040000');
     });
   });
 


### PR DESCRIPTION
The Version contract defined the version as the string "305" and the function returns a bytes3 value. The string "305" was encoded and the returned as 0x333035. This limited patch increments to the versioning. For example, we would not be able to fit the string "3010" (for version 3.0.10) into bytes3.

The update changes the version encoding to be simply 3 digits, base 256 number. This allows major, minor, and patch numbers up to 255.

The update was suggested by OpenZeppelin reviewer; no issue reference was assigned.