### PR TITLE
Replace Ownable package for contants manager

### DIFF
--- a/contracts/sfc/ConstantsManager.sol
+++ b/contracts/sfc/ConstantsManager.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.27;
 
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Decimal} from "../common/Decimal.sol";
 
 /**
  * @custom:security-contact security@fantom.foundation
  */
-contract ConstantsManager is OwnableUpgradeable {
+contract ConstantsManager is Ownable {
     // Minimum amount of stake for a validator, i.e., 500000 FTM
     uint256 public minSelfStake;
     // Maximum ratio of delegations a validator can have, say, 15 times of self-stake
@@ -47,9 +47,7 @@ contract ConstantsManager is OwnableUpgradeable {
      */
     error ValueTooLarge();
 
-    constructor(address owner) initializer {
-        __Ownable_init(owner);
-    }
+    constructor(address owner) Ownable(owner) {}
 
     function updateMinSelfStake(uint256 v) external virtual onlyOwner {
         if (v < 100000 * 1e18) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.0.5-rc.1",
       "license": "MIT",
       "dependencies": {
+        "@openzeppelin/contracts": "^5.1.0",
         "@openzeppelin/contracts-upgradeable": "^5.1.0",
         "dotenv": "^16.0.3"
       },
@@ -1618,8 +1619,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.1.0.tgz",
       "integrity": "sha512-p1ULhl7BXzjjbha5aqst+QMLY+4/LCWADXOCsmLHRM77AqiPjnd9vvUN9sosUfhL9JGKpZ0TjEGxgvnizmWGSA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@openzeppelin/contracts-upgradeable": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "typescript-eslint": "^8.8.0"
   },
   "dependencies": {
+    "@openzeppelin/contracts": "^5.1.0",
     "@openzeppelin/contracts-upgradeable": "^5.1.0",
     "dotenv": "^16.0.3"
   }


### PR DESCRIPTION
This PR replaces `OwnableUpgradeable` package with `Ownable` package for constants manager.