### PR TITLE
[OZ][L-01] Fix inaccurate uptime calculation due to remainder

### DIFF
--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -1014,6 +1014,7 @@ contract SFC is OwnableUpgradeable, UUPSUpgradeable, Version {
 
         if (cur.averageUptime > Decimal.unit()) {
             cur.averageUptime = uint64(Decimal.unit());
+            cur.remainder = 0; // reset the remainder when capping the averageUptime
         }
         if (prev.epochs < c.averageUptimeEpochWindow()) {
             cur.epochs = prev.epochs + 1;


### PR DESCRIPTION
This PR fixes resetting remainder to zero whenever the `averageUptime` exceeds `1e18` and is capped at `1e18`.