### PR TITLE
[OZ][L-02] Transfer and send Calls Are No Longer Considered Best Practice

### DIFF
--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -835,7 +835,10 @@ contract SFC is OwnableUpgradeable, UUPSUpgradeable, Version {
                 revert ValueTooLarge();
             }
             totalSupply -= amount;
-            payable(address(0)).call{value: amount}("");
+            (bool sent, ) = payable(address(0)).call{value: amount}("");
+            if (!sent) {
+                revert TransferFailed();
+            }
             emit BurntNativeTokens(amount);
         }
     }

--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -772,7 +772,7 @@ contract SFC is OwnableUpgradeable, UUPSUpgradeable, Version {
     /// The tokens are sent to the zero address.
     function _burnFTM(uint256 amount) internal {
         if (amount != 0) {
-            payable(address(0)).transfer(amount);
+            payable(address(0)).call{value: amount}("");
             emit BurntFTM(amount);
         }
     }


### PR DESCRIPTION
This PR replaces `transfer` call with `call` as it is not considered best practise.