### PR TITLE
[OZ][L-03] Unsafe ABI Encoding

### DIFF
--- a/contracts/interfaces/IStakeSubscriber.sol
+++ b/contracts/interfaces/IStakeSubscriber.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.27;
+
+/**
+ * @title Stake Subscriber Interface
+ * @notice Used to recount votes from delegators in the governance contract
+ * @custom:security-contact security@fantom.foundation
+ */
+interface IStakeSubscriber {
+    function announceStakeChange(address delegator, address validator) external;
+}

--- a/contracts/sfc/SFC.sol
+++ b/contracts/sfc/SFC.sol
@@ -7,6 +7,7 @@ import {Decimal} from "../common/Decimal.sol";
 import {NodeDriverAuth} from "./NodeDriverAuth.sol";
 import {ConstantsManager} from "./ConstantsManager.sol";
 import {Version} from "../version/Version.sol";
+import {IStakeSubscriber} from "../interfaces/IStakeSubscriber.sol";
 
 /**
  * @title Special Fee Contract for Sonic network
@@ -1052,7 +1053,7 @@ contract SFC is OwnableUpgradeable, UUPSUpgradeable, Version {
             // Don't allow announceStakeChange to use up all the gas
             // solhint-disable-next-line avoid-low-level-calls
             (bool success, ) = stakeSubscriberAddress.call{gas: 8000000}(
-                abi.encodeWithSignature("announceStakeChange(address,address)", delegator, validatorAuth)
+                abi.encodeCall(IStakeSubscriber.announceStakeChange, (delegator, validatorAuth))
             );
             // Don't revert if announceStakeChange failed unless strict mode enabled
             if (!success && strict) {


### PR DESCRIPTION
This PR replaces unsafe `abi.encodeWithSignature` with type safe `abi.encodeCall`.