### PR TITLE
[OZ][N-07] Inconsistent Use of Decimal.unit() and 1e18

### DIFF
--- a/contracts/sfc/ConstantsManager.sol
+++ b/contracts/sfc/ConstantsManager.sol
@@ -52,10 +52,10 @@ contract ConstantsManager is OwnableUpgradeable {
     }
 
     function updateMinSelfStake(uint256 v) external virtual onlyOwner {
-        if (v < 100000 * 1e18) {
+        if (v < 100000 * Decimal.unit()) {
             revert ValueTooSmall();
         }
-        if (v > 10000000 * 1e18) {
+        if (v > 10000000 * Decimal.unit()) {
             revert ValueTooLarge();
         }
         minSelfStake = v;
@@ -113,10 +113,10 @@ contract ConstantsManager is OwnableUpgradeable {
     }
 
     function updateBaseRewardPerSecond(uint256 v) external virtual onlyOwner {
-        if (v < 0.5 * 1e18) {
+        if (v < Decimal.unit() / 2) {
             revert ValueTooSmall();
         }
-        if (v > 32 * 1e18) {
+        if (v > 32 * Decimal.unit()) {
             revert ValueTooLarge();
         }
         baseRewardPerSecond = v;

--- a/contracts/sfc/NetworkInitializer.sol
+++ b/contracts/sfc/NetworkInitializer.sol
@@ -25,7 +25,7 @@ contract NetworkInitializer {
         NodeDriverAuth(_auth).initialize(_sfc, _driver, _owner);
 
         ConstantsManager consts = new ConstantsManager(address(this));
-        consts.updateMinSelfStake(500000 * 1e18);
+        consts.updateMinSelfStake(500000 * Decimal.unit());
         consts.updateMaxDelegatedRatio(16 * Decimal.unit());
         consts.updateValidatorCommission((15 * Decimal.unit()) / 100);
         consts.updateBurntFeeShare((20 * Decimal.unit()) / 100);

--- a/contracts/test/UnitTestSFC.sol
+++ b/contracts/test/UnitTestSFC.sol
@@ -62,7 +62,7 @@ contract UnitTestNetworkInitializer {
         NodeDriverAuth(_auth).initialize(_sfc, _driver, _owner);
 
         UnitTestConstantsManager consts = new UnitTestConstantsManager(address(this));
-        consts.updateMinSelfStake(0.3175000 * 1e18);
+        consts.updateMinSelfStake((3175 * Decimal.unit()) / 10000);
         consts.updateMaxDelegatedRatio(16 * Decimal.unit());
         consts.updateValidatorCommission((15 * Decimal.unit()) / 100);
         consts.updateBurntFeeShare((20 * Decimal.unit()) / 100);


### PR DESCRIPTION
This PR fixes inconsistent use of `Decimal.unit()` across the contracts.